### PR TITLE
Fix the preview that will appear in unfurled dashboard links

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -20,10 +20,10 @@
       rel="stylesheet"
     />
 
-    <title>Minimal UI Kit</title>
+    <title>Network performance</title>
     <meta
       name="description"
-      content="The starting point for your next project with Minimal UI Kit, built on the newest version of Material-UI ©, ready to be customized to your style"
+      content="Performance data for Microsoft-owned networking projects."
     />
     <meta name="keywords" content="react,material,kit,application,dashboard,admin,template" />
     <meta name="author" content="Minimal UI Kit" />


### PR DESCRIPTION
Update the part of index.html that appears in unfurled links to the dashboard, which currently looks like this:
 
![image](https://github.com/microsoft/netperf/assets/26825838/43ab773d-a8ef-45fa-86c8-8e5fe9610d3d)
