### PR TITLE
Disable chart animations

### DIFF
--- a/dashboard/src/components/chart/use-chart.js
+++ b/dashboard/src/components/chart/use-chart.js
@@ -46,7 +46,7 @@ export default function useChart(options) {
     chart: {
       toolbar: { show: false },
       zoom: { enabled: false },
-      // animations: { enabled: false },
+      animations: { enabled: false },
       foreColor: theme.palette.text.disabled,
       fontFamily: theme.typography.fontFamily,
     },


### PR DESCRIPTION
Currently there is an animation that makes the time series pop up one after another, which means you have to wait ~2sec to see the full chart. This is an unreasonable wait and makes it impossible to quickly click back and forth between e.g. the latency and RPS views to compare them.