### PR TITLE
'Pwsh' not working; fix by running command directly

### DIFF
--- a/setup-runner-windows.ps1
+++ b/setup-runner-windows.ps1
@@ -42,7 +42,7 @@ if (!$HasTestSigning) {
 # Enable PowerShell remoting to peer.
 Write-Host "Enabling Remote PowerShell."
 "$PeerIp netperf-peer" | Out-File -Encoding ASCII -Append "$env:SystemRoot\System32\drivers\etc\hosts"
-pwsh -Command 'Enable-PSRemoting -Force'
+Enable-PSRemoting -Force
 Set-Item WSMan:\localhost\Client\TrustedHosts -Value 'netperf-peer'
 
 # Disable Windows defender / firewall.


### PR DESCRIPTION
User is already running script in the context of powershell. 

Why are we explicitly specifying "pwsh"? Also, this throws an error because powershell 7 hasn't been loaded yet. 