### PR TITLE
Add new required input

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -60,6 +60,7 @@ jobs:
       build_artifact: Build-x64
       build_msi: true
       build_nuget: true
+      repository: 'microsoft/ebpf-for-windows'
       configurations: '["NativeOnlyRelease"]'
       ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
 


### PR DESCRIPTION
eBPF for Windows reusable build YAML added a new repository input as mandatory.