### PR TITLE
Pass perform skip check = false to reusable build

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -64,6 +64,7 @@ jobs:
       repository: 'microsoft/ebpf-for-windows'
       configurations: '["NativeOnlyRelease"]'
       ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
+      perform_skip_check: false
 
   test:
     name: Test Windows eBPF Performance


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/ebpf.yml` file. The change introduces a new parameter `perform_skip_check` in the `jobs:` section, which is set to `false`. 