### PR TITLE
Fix WPR stop command

### DIFF
--- a/.github/workflows/cts_traffic.yml
+++ b/.github/workflows/cts_traffic.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Stop Windows Performance Recorder
       if: ${{ github.event.inputs.profile }}
       run: |
-        wpr -stop -file ${{ github.workspace }}\ETL\ctsTrafficResults.etl
+        wpr -stop ${{ github.workspace }}\ETL\ctsTrafficResults.etl
 
     - name: Upload CTS cts-traffic results
       if: always()


### PR DESCRIPTION
This pull request includes a minor modification to the `cts_traffic.yml` workflow file. The change specifically involves the command used to stop the Windows Performance Recorder in the job.

* [`.github/workflows/cts_traffic.yml`](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L96-R96): The `wpr -stop` command has been updated to remove the `-file` flag. The command now directly takes the path to the `ctsTrafficResults.etl` file as an argument.