### PR TITLE
Fix cts traffic

### DIFF
--- a/.github/workflows/cts_traffic.yml
+++ b/.github/workflows/cts_traffic.yml
@@ -78,7 +78,8 @@ jobs:
     - name: Start Windows Performance Recorder
       if: ${{ github.event.inputs.profile }}
       run: |
-        wpr -start CPU -filemode 
+        wpr -cancel
+        wpr -start CPU -filemode
 
     - name: Run CTS cts-traffic
       working-directory: ${{ github.workspace }}\cts-traffic

--- a/.github/workflows/cts_traffic.yml
+++ b/.github/workflows/cts_traffic.yml
@@ -9,11 +9,6 @@ on:
   # Permit manual runs of the workflow.
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'CTS Trafic Branch or Commit'
-        required: false
-        default: 'main'
-        type: string
       profile:
         description: 'Capture CPU profile'
         required: false
@@ -42,7 +37,7 @@ jobs:
       build_artifact: cts-traffic
       repository: 'microsoft/ctsTraffic'
       configurations: '["Release"]'
-      ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'master' }}
+      ref: 'master'
 
   test:
     name: Test CTS Traffic

--- a/.github/workflows/cts_traffic.yml
+++ b/.github/workflows/cts_traffic.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Stop Windows Performance Recorder
       if: ${{ github.event.inputs.profile }}
       run: |
-        wpr -stop -file ${{ github.workspace }}\ETL\ctsTrafficResults.etl
+        wpr -stop ${{ github.workspace }}\ETL\ctsTrafficResults.etl
 
     - name: Upload CTS cts-traffic results
       if: always()

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -73,7 +73,7 @@ jobs:
       build_artifact: cts-traffic
       repository: 'microsoft/ctsTraffic'
       configurations: '["Release"]'
-      ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'master' }}
+      ref: 'master'
 
   test:
     name: Test Windows eBPF Performance


### PR DESCRIPTION
This pull request primarily modifies the GitHub Actions workflows `cts_traffic.yml` and `ebpf.yml`. The changes include the removal of the `ref` input from the `workflow_dispatch` trigger, the hardcoding of the `ref` value to 'master' in the jobs, and adjustments to the Windows Performance Recorder commands in the `cts_traffic.yml` workflow.

Changes to the `workflow_dispatch` trigger:

* [`.github/workflows/cts_traffic.yml`](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L12-L16): Removed the `ref` input from the `workflow_dispatch` trigger. This input was previously used to specify the branch or commit for the Continuous Traffic Shaping (CTS) traffic.

Changes to the `ref` value in jobs:

* [`.github/workflows/cts_traffic.yml`](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L45-R40): Changed the `ref` value in the jobs to be hardcoded as 'master'. This was previously dynamically set based on various GitHub event parameters or the `ref` input.
* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL76-R76): Similar to the `cts_traffic.yml` file, the `ref` value in the jobs is now hardcoded as 'master'.

Changes to Windows Performance Recorder commands:

* [`.github/workflows/cts_traffic.yml`](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213R76): Added a command to cancel any existing Windows Performance Recorder (WPR) profiling before starting a new one. Also, adjusted the command to stop the WPR to no longer include the `-file` option. [[1]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213R76) [[2]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L96-R92)