### PR TITLE
Fixup cts traffic formatting

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -164,12 +164,16 @@ jobs:
     - name: Run CTS cts-traffic
       working-directory: ${{ github.workspace }}\cts-traffic
       # Note: The script is not in the repository, but is downloaded from the web.
-      # The resulting CSV file's header is updated to match the format produced by the BPF performance tests.
-      # The "Average Duration (ns)" column is the metric of interest.
       run: |
         dir .
         $url = "https://raw.githubusercontent.com/microsoft/bpf_performance/main/scripts/two-machine-perf.ps1"
         iex "& { $(irm $url) }"
+
+      # The resulting CSV file's header is updated to match the format produced by the BPF performance tests.
+      # The "Average Duration (ns)" column is the metric of interest.
+    - name: Fixup cts traffic results
+      working-directory: ${{ github.workspace }}\cts-traffic
+      run: |
         $content = Get-Content ctsTrafficResults.csv
         $content[0] = "Timestamp,Test,Average Duration (ns)"
         $content | Set-Content ctsTrafficResults.csv


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/ebpf.yml` file. The change modifies the `jobs:` section, specifically the `Run CTS cts-traffic` job. The original comment about the CSV file's header and the "Average Duration (ns)" column has been moved down, and a new job called `Fixup cts traffic results` has been added. This new job works in the `cts-traffic` directory and updates the header of the `ctsTrafficResults.csv` file to match the format produced by the BPF performance tests.