### PR TITLE
Purge old ebpf install

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -106,6 +106,11 @@ jobs:
         New-item -ItemType Directory -Path ${{ github.workspace }}\cts-traffic
         New-item -ItemType Directory -Path ${{ github.workspace }}\ETL
 
+    - name: Cleanup eBPF
+      run: |
+        $url = "https://raw.githubusercontent.com/Alan-Jowett/ebpf-for-windows/0e409d1bc6880143f321bf87c497a86ce7f30b45/scripts/Cleanup-Installer.ps1"
+        iex "& { $(irm $url) }"
+
     - name: Download ebpf-for-windows
       uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe
       with:


### PR DESCRIPTION
This pull request includes a significant change to the `.github/workflows/ebpf.yml` file. The change introduces a new step in the GitHub Actions workflow that cleans up eBPF before downloading eBPF for Windows. 

* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bR109-R113): Added a new step named "Cleanup eBPF" in the GitHub Actions workflow. This step runs a PowerShell script from a URL to clean up eBPF before the step "Download ebpf-for-windows" is executed.