### PR TITLE
Switch to latest xdp and bpf_performance

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -155,7 +155,7 @@ jobs:
     - name: Download bpf_performance repository artifacts
       working-directory: ${{ github.workspace }}\bpf_performance
       run: |
-        Invoke-WebRequest https://github.com/microsoft/bpf_performance/releases/download/v0.0.7/build-Release-windows-2022.zip -OutFile bpf_performance.zip
+        Invoke-WebRequest https://github.com/microsoft/bpf_performance/releases/download/v0.0.8/build-Release-windows-2022.zip -OutFile bpf_performance.zip
 
     - name: Unzip bpf_performance repository artifacts
       working-directory: ${{ github.workspace }}\bpf_performance

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -128,10 +128,10 @@ jobs:
       working-directory: ${{ github.workspace }}\xdp
       run: |
         $ProgressPreference = 'SilentlyContinue'
-        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2Bc10f37fa/xdp-for-windows.1.1.0.msi"
+        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2B3b7480bf/xdp-devkit-x64-1.1.0.zip"
         Invoke-WebRequest -Uri $packageUrl -OutFile xdp-for-windows.1.1.0.msi
         dir *.msi
-        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0+c10f37fa/xdp-devkit-x64-1.1.0.zip"
+        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2B3b7480bf/xdp-for-windows.1.1.0.msi"
         Invoke-WebRequest -Uri $packageUrl -OutFile xdp-devkit-x64-1.1.0.zip
         dir *.zip
         Expand-Archive -Path "xdp-devkit-x64-1.1.0.zip" -DestinationPath .
@@ -155,7 +155,7 @@ jobs:
     - name: Download bpf_performance repository artifacts
       working-directory: ${{ github.workspace }}\bpf_performance
       run: |
-        Invoke-WebRequest https://github.com/microsoft/bpf_performance/releases/download/v0.0.6/build-Release-windows-2022.zip -OutFile bpf_performance.zip
+        Invoke-WebRequest https://github.com/microsoft/bpf_performance/releases/download/v0.0.7/build-Release-windows-2022.zip -OutFile bpf_performance.zip
 
     - name: Unzip bpf_performance repository artifacts
       working-directory: ${{ github.workspace }}\bpf_performance

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -128,10 +128,10 @@ jobs:
       working-directory: ${{ github.workspace }}\xdp
       run: |
         $ProgressPreference = 'SilentlyContinue'
-        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2B3b7480bf/xdp-devkit-x64-1.1.0.zip"
+        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2B3b7480bf/xdp-for-windows.1.1.0.msi"
         Invoke-WebRequest -Uri $packageUrl -OutFile xdp-for-windows.1.1.0.msi
         dir *.msi
-        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2B3b7480bf/xdp-for-windows.1.1.0.msi"
+        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2B3b7480bf/xdp-devkit-x64-1.1.0.zip"
         Invoke-WebRequest -Uri $packageUrl -OutFile xdp-devkit-x64-1.1.0.zip
         dir *.zip
         Expand-Archive -Path "xdp-devkit-x64-1.1.0.zip" -DestinationPath .


### PR DESCRIPTION
This pull request primarily updates URLs for downloading packages in the `.github/workflows/ebpf.yml` file. The changes ensure the workflow uses the latest versions of the `xdp-for-windows` and `bpf_performance` packages.

Here are the key changes:

* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL131-R134): Updated the download URLs for the `xdp-for-windows` package. The new URLs point to the `v1.1.0%2B3b7480bf` version of the package, replacing the previous `v1.1.0%2Bc10f37fa` version.
* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL158-R158): Updated the download URL for the `bpf_performance` package. The new URL points to the `v0.0.8` version of the package, replacing the previous `v0.0.6` version.