### PR TITLE
Remove broken Azure 2025 workers

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -83,7 +83,7 @@ jobs:
       matrix:
         vec: [
           { env: "azure", os: "2022", arch: "x64" },
-          { env: "azure", os: "2025", arch: "x64" },
+          #{ env: "azure", os: "2025", arch: "x64" }, # F4 based VMS are being deprecated by netperf team.
           { env: "lab",   os: "2022", arch: "x64" },
         ]
     runs-on:


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/ebpf.yml` file. The change comments out an environment configuration in the `jobs:` section for the year "2025" because F4 based VMs are being deprecated by the netperf team.