### PR TITLE
Run XDP tests only on lab machine

### DIFF
--- a/.github/workflows/xdp.yml
+++ b/.github/workflows/xdp.yml
@@ -59,8 +59,6 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { env: "azure", os: "2022", arch: "x64" },
-          { env: "azure", os: "2025", arch: "x64" },
           { env: "lab",   os: "2022", arch: "x64" },
         ]
     runs-on:


### PR DESCRIPTION
The rest of the environments haven't stabilized, so run XDP perf tests only on the lab machines.