### PR TITLE
Update XDP version

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -32,7 +32,7 @@ on:
       # Args: { guid, sha, ref, pr }
 
 env:
-  XDP_VERSION: 'v1.1.0%2B3b7480bf'
+  XDP_VERSION: '1.1.0'
 
 concurrency:
   group: ebpf-${{ github.event.client_payload.pr || github.event.client_payload.sha || inputs.ref || github.event.pull_request.number || 'main' }}
@@ -136,13 +136,12 @@ jobs:
       working-directory: ${{ github.workspace }}\xdp
       run: |
         $ProgressPreference = 'SilentlyContinue'
-        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/${{env.XDP_VERSION}}/xdp-for-windows.1.1.0.msi"
-        Invoke-WebRequest -Uri $packageUrl -OutFile xdp-for-windows.1.1.0.msi
+        $releases = (gh release -R microsoft/xdp-for-windows list --json name,isPrerelease,createdAt | ConvertFrom-Json)
+        $release = ($releases | Where-Object -Property isPrerelease -eq true | Sort-Object -Property createdAt -Descending)[0]
+        gh release download -R microsoft/xdp-for-windows $release.name
         dir *.msi
-        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/${{env.XDP_VERSION}}/xdp-devkit-x64-1.1.0.zip"
-        Invoke-WebRequest -Uri $packageUrl -OutFile xdp-devkit-x64-1.1.0.zip
         dir *.zip
-        Expand-Archive -Path "xdp-devkit-x64-1.1.0.zip" -DestinationPath .
+        Expand-Archive -Path "xdp-devkit-x64-${{env.XDP_VERSION}}.zip" -DestinationPath .
 
     - name: Install xdp-for-windows
       working-directory: ${{ github.workspace }}\xdp
@@ -152,7 +151,7 @@ jobs:
           Write-Output "Installing XDP for Windows"
           CertUtil.exe -addstore Root bin\CoreNetSignRoot.cer
           CertUtil.exe -addstore TrustedPublisher bin\CoreNetSignRoot.cer
-          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.1.1.0.msi INSTALLFOLDER=$installPath /qn" -PassThru
+          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.${{env.XDP_VERSION}}.msi INSTALLFOLDER=$installPath /qn" -PassThru
           if ($process.ExitCode -ne 0) { exit $process.ExitCode }
           Write-Output "XDP for Windows installed"
           sc.exe query xdp

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -162,12 +162,14 @@ jobs:
     - name: Download bpf_performance repository artifacts
       working-directory: ${{ github.workspace }}\bpf_performance
       run: |
-        Invoke-WebRequest https://github.com/microsoft/bpf_performance/releases/download/v0.0.9/build-Release-windows-2022.zip -OutFile bpf_performance.zip
+        $releases = (gh release -R microsoft/bpf_performance list --json name,createdAt | ConvertFrom-Json)
+        $release = ($releases | Sort-Object -Property createdAt -Descending)[0]
+        gh release download -R microsoft/bpf_performance $release.name
 
     - name: Unzip bpf_performance repository artifacts
       working-directory: ${{ github.workspace }}\bpf_performance
       run: |
-        Expand-Archive -Path bpf_performance.zip -DestinationPath .
+        Expand-Archive -Path build-Release-windows-2022.zip -DestinationPath .
 
     - name: Download cts-traffic
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -120,6 +120,8 @@ jobs:
         Add-MpPreference -ExclusionPath ${{ github.workspace }}
 
     - name: Download GH CLI if not installed
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         if (-not (Test-Path -Path "C:\Program Files\GitHub CLI\gh.exe")) {
         $url = "https://github.com/cli/cli/releases/download/v2.48.0/gh_2.48.0_windows_amd64.msi"
@@ -142,9 +144,10 @@ jobs:
         echo "C:\Program Files\ebpf-for-windows" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Download xdp-for-windows
+      env:
+        GH_TOKEN: ${{ github.token }}
       working-directory: ${{ github.workspace }}\xdp
       run: |
-        
         $ProgressPreference = 'SilentlyContinue'
         $releases = (gh release -R microsoft/xdp-for-windows list --json name,isPrerelease,createdAt | ConvertFrom-Json)
         $release = ($releases | Where-Object -Property isPrerelease -eq true | Sort-Object -Property createdAt -Descending)[0]

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -119,6 +119,15 @@ jobs:
         Start-MpScan -ScanType QuickScan
         Add-MpPreference -ExclusionPath ${{ github.workspace }}
 
+    - name: Download GH CLI if not installed
+      run: |
+        if (-not (Test-Path -Path "C:\Program Files\GitHub CLI\gh.exe")) {
+        $url = "https://github.com/cli/cli/releases/download/v2.48.0/gh_2.48.0_windows_amd64.msi"
+        Invoke-WebRequest -Uri $url -OutFile "gh.msi"
+        Start-Process -FilePath "msiexec" -ArgumentList "/i gh.msi /quiet /qn /norestart /log install.log" -Wait -NoNewWindow
+        }
+        echo "C:\Program Files\GitHub CLI" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
     - name: Download ebpf-for-windows
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       with:
@@ -135,6 +144,7 @@ jobs:
     - name: Download xdp-for-windows
       working-directory: ${{ github.workspace }}\xdp
       run: |
+        
         $ProgressPreference = 'SilentlyContinue'
         $releases = (gh release -R microsoft/xdp-for-windows list --json name,isPrerelease,createdAt | ConvertFrom-Json)
         $release = ($releases | Where-Object -Property isPrerelease -eq true | Sort-Object -Property createdAt -Descending)[0]

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -31,6 +31,9 @@ on:
     types: [run-ebpf]
       # Args: { guid, sha, ref, pr }
 
+env:
+  XDP_VERSION: 'v1.1.0%2B3b7480bf'
+
 concurrency:
   group: ebpf-${{ github.event.client_payload.pr || github.event.client_payload.sha || inputs.ref || github.event.pull_request.number || 'main' }}
   cancel-in-progress: true
@@ -133,10 +136,10 @@ jobs:
       working-directory: ${{ github.workspace }}\xdp
       run: |
         $ProgressPreference = 'SilentlyContinue'
-        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2B3b7480bf/xdp-for-windows.1.1.0.msi"
+        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/${{env.XDP_VERSION}}/xdp-for-windows.1.1.0.msi"
         Invoke-WebRequest -Uri $packageUrl -OutFile xdp-for-windows.1.1.0.msi
         dir *.msi
-        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2B3b7480bf/xdp-devkit-x64-1.1.0.zip"
+        $packageUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/${{env.XDP_VERSION}}/xdp-devkit-x64-1.1.0.zip"
         Invoke-WebRequest -Uri $packageUrl -OutFile xdp-devkit-x64-1.1.0.zip
         dir *.zip
         Expand-Archive -Path "xdp-devkit-x64-1.1.0.zip" -DestinationPath .

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -174,6 +174,8 @@ jobs:
 
     - name: Download bpf_performance repository artifacts
       working-directory: ${{ github.workspace }}\bpf_performance
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         $releases = (gh release -R microsoft/bpf_performance list --json name,createdAt | ConvertFrom-Json)
         $release = ($releases | Sort-Object -Property createdAt -Descending)[0]


### PR DESCRIPTION
This pull request primarily focuses on improving the automation and version control in the `.github/workflows/ebpf.yml` file. The changes include the addition of an environment variable for the XDP version, and the modification of the jobs to dynamically fetch and use the latest versions of `xdp-for-windows` and `bpf_performance` from their respective GitHub releases. This eliminates the need to manually update the version numbers in the script whenever a new version is released.

Environment variable addition:

* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bR34-R36): Added `XDP_VERSION` environment variable to control the version of XDP used in the workflow.

Dynamic version fetching:

* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL136-R144): Modified the job steps to fetch the latest prerelease of `xdp-for-windows` from GitHub releases, and use the `XDP_VERSION` environment variable for file names. This replaces the previous static download links. [[1]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL136-R144) [[2]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL152-R154)
* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL163-R172): Updated the job steps to fetch the latest release of `bpf_performance` from GitHub releases, replacing the previous static download link.