### PR TITLE
Install vc_redist before running tests

### DIFF
--- a/.github/workflows/ebpf_dynamic_vm.yml
+++ b/.github/workflows/ebpf_dynamic_vm.yml
@@ -143,6 +143,12 @@ jobs:
         }
         echo "C:\Program Files\GitHub CLI" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+    - name: Install VC redistributable
+      run: |
+        $url = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+        Invoke-WebRequest -Uri $url -OutFile "vc_redist.x64.exe"
+        Start-Process -FilePath "vc_redist.x64.exe" -ArgumentList "/quiet /qn /norestart" -Wait -NoNewWindow
+
     - name: Download ebpf-for-windows
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       with:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/ebpf_dynamic_vm.yml` file. The change adds a new job step to install the Visual C++ redistributable on the Windows virtual machine before downloading and running the eBPF for Windows artifact.

* [`.github/workflows/ebpf_dynamic_vm.yml`](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fR146-R151): Added a new job step to install the Visual C++ redistributable. This ensures that the necessary runtime components for Visual C++ applications are available on the Windows virtual machine.