### PR TITLE
Switch the ebpf-dynamic_vm workflow into it's own concurrency group

### DIFF
--- a/.github/workflows/ebpf_dynamic_vm.yml
+++ b/.github/workflows/ebpf_dynamic_vm.yml
@@ -4,7 +4,7 @@
 # This workflow will download the latest ebpf-for-windows MSI installer and run
 # the BPF performance tests. The results will be uploaded as an artifact.
 
-name: ebpf-for-windows
+name: ebpf-for-windows-dynamic
 
 on:
   # Permit manual runs of the workflow.
@@ -28,14 +28,14 @@ on:
     - .github/workflows/ebpf_dynamic.yml
 
   repository_dispatch:
-    types: [run-ebpf]
+    types: [run-ebpf-dynamic]
       # Args: { guid, sha, ref, pr }
 
 env:
   XDP_VERSION: '1.1.0'
 
 concurrency:
-  group: ebpf-${{ github.event.client_payload.pr || github.event.client_payload.sha || inputs.ref || github.event.pull_request.number || 'main' }}
+  group: ebpf-dynamic-${{ github.event.client_payload.pr || github.event.client_payload.sha || inputs.ref || github.event.pull_request.number || 'main' }}
   cancel-in-progress: true
 
 # Need to determine why this is required.


### PR DESCRIPTION
This pull request primarily modifies the `.github/workflows/ebpf_dynamic_vm.yml` file. The changes are related to renaming some identifiers to include the term "dynamic". 

The most important changes are:

* [`.github/workflows/ebpf_dynamic_vm.yml`](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fL7-R7): The name of the workflow has been changed from `ebpf-for-windows` to `ebpf-for-windows-dynamic`. This change is likely to affect how this workflow is referenced in other parts of the codebase or in the GitHub Actions UI.
* [`.github/workflows/ebpf_dynamic_vm.yml`](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fL31-R38): The `repository_dispatch` types have been updated from `run-ebpf` to `run-ebpf-dynamic`. This change could impact any external triggers that were previously set up to start this workflow.
* [`.github/workflows/ebpf_dynamic_vm.yml`](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fL31-R38): The `concurrency` group name has been updated to include "dynamic". This change may affect how concurrent runs of this workflow are grouped and managed.