### PR TITLE
Remove RIO because of Instability

### DIFF
--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -2,7 +2,6 @@
     { "env": "azure", "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll" },
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp" },
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp" },
-    { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "rio" },
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp" },


### PR DESCRIPTION
RIO too often has problems. Let's remove it for now.