### PR TITLE
Remove failing worker pools

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -85,9 +85,9 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { env: "azure", os: "2022", arch: "x64" },
+          #{ env: "azure", os: "2022", arch: "x64" }, # Azure VMs are being deprecated by netperf team.
           #{ env: "azure", os: "2025", arch: "x64" }, # F4 based VMS are being deprecated by netperf team.
-          { env: "lab",   os: "2022", arch: "x64" },
+          { env: "lab",   os: "2022", arch: "x64" }, 
         ]
     runs-on:
     - self-hosted


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/ebpf.yml` file. The change comments out the configuration for the Azure VMs in the matrix as they are being deprecated by the netperf team.