### PR TITLE
Update cts traffic workflow

### DIFF
--- a/.github/workflows/cts_traffic.yml
+++ b/.github/workflows/cts_traffic.yml
@@ -14,6 +14,11 @@ on:
         required: false
         default: false
         type: boolean
+      tcp_ip_tracing:
+        description: 'Capture TCP/IP tracing'
+        required: false
+        default: false
+        type: boolean
 
   pull_request:
     branches:
@@ -46,8 +51,8 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { env: "azure", os: "2022", arch: "x64" },
-          { env: "azure", os: "2025", arch: "x64" },
+          # { env: "azure", os: "2022", arch: "x64" },
+          # { env: "azure", os: "2025", arch: "x64" },
           { env: "lab",   os: "2022", arch: "x64" },
         ]
     runs-on:
@@ -59,6 +64,7 @@ jobs:
     steps:
     - name: Setup workspace
       run: |
+        Get-ChildItem  | % { Remove-Item -Recurse $_ }
         if (Test-Path ${{ github.workspace }}\xdp) { Remove-Item -Recurse -Force ${{ github.workspace }}\cts-traffic }
         if (Test-Path ${{ github.workspace }}\ETL) { Remove-Item -Recurse -Force ${{ github.workspace }}\ETL }
         New-item -ItemType Directory -Path ${{ github.workspace }}\cts-traffic
@@ -78,6 +84,14 @@ jobs:
         name: "cts-traffic Release"
         path: ${{ github.workspace }}\cts-traffic
 
+    - name: Start TCPIP tracing
+      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      run: |
+        wpr -cancel 2>$null; $global:LASTEXITCODE = 0
+        if (Test-Path "tcpip.wprp") { Remove-Item -Force "tcpip.wprp" }
+        Invoke-WebRequest -uri "https://raw.githubusercontent.com/microsoft/netperf/main/.github/workflows/tcpip.wprp" -OutFile "tcpip.wprp"
+        wpr -start tcpip.wprp -filemode
+
     - name: Run CTS cts-traffic
       working-directory: ${{ github.workspace }}\cts-traffic
       run: |
@@ -86,12 +100,18 @@ jobs:
         $url = "https://raw.githubusercontent.com/microsoft/bpf_performance/main/scripts/two-machine-perf.ps1"
         iex "& { $(irm $url) } -CpuProfile $profile"
 
+    - name: Stop TCPIP tracing
+      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      run: |
+        wpr -stop ${{ github.workspace }}\ETL\tcpip.etl
+
     - name: Move ETL files to ETLfolder 
       working-directory: ${{ github.workspace }}\cts-traffic
       run: |
         dir .
         if (Test-Path ${{ github.workspace }}\cts-traffic\cts_traffic_recv.etl) { Move-Item ${{ github.workspace }}\cts-traffic\cts_traffic_recv.etl ${{ github.workspace }}\ETL }
         if (Test-Path ${{ github.workspace }}\cts-traffic\cts_traffic_send.etl) { Move-Item ${{ github.workspace }}\cts-traffic\cts_traffic_send.etl ${{ github.workspace }}\ETL }
+        if (Test-Path ${{ github.workspace }}\cts-traffic\tcpip_baseline.etl) { Move-Item ${{ github.workspace }}\cts-traffic\tcpip_baseline.etl ${{ github.workspace }}\ETL }
 
     - name: Upload CTS cts-traffic results
       if: always()
@@ -101,7 +121,7 @@ jobs:
         path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv 
 
     - name: Upload ETL
-      if: ${{ github.event.inputs.profile }}
+      if: ${{ github.event.inputs.profile }} || ${{ github.event.inputs.tcp_ip_tracing }}
       uses: actions/upload-artifact@v2
       with:
         name: cts_traffic_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}_ETL

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -103,6 +103,7 @@ jobs:
     steps:
     - name: Setup workspace
       run: |
+        Get-ChildItem  | % { Remove-Item -Recurse $_ }
         $process = Start-Process -FilePath "msiexec" -ArgumentList "/x {022C44B5-8969-4B75-8DB0-73F98B1BD7DC} /quiet /qn /norestart /log uninstall.log" -Wait -NoNewWindow
         $process = Start-Process -FilePath "msiexec" -ArgumentList "/x {9363C0E3-4DE9-4067-9F5E-6A1A06034B59} /quiet /qn /norestart /log uninstall.log" -Wait -NoNewWindow
         $url = "https://raw.githubusercontent.com/microsoft/ebpf-for-windows/main/scripts/Cleanup-Installer.ps1"
@@ -197,6 +198,14 @@ jobs:
         name: "cts-traffic Release"
         path: ${{ github.workspace }}\cts-traffic
 
+    - name: Start TCPIP tracing - Baseline
+      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      run: |
+        wpr -cancel 2>$null; $global:LASTEXITCODE = 0
+        if (Test-Path "tcpip.wprp") { Remove-Item -Force "tcpip.wprp" }
+        Invoke-WebRequest -uri "https://raw.githubusercontent.com/microsoft/netperf/main/.github/workflows/tcpip.wprp" -OutFile "tcpip.wprp"
+        wpr -start tcpip.wprp -filemode
+
     # Run CTS traffic without XDP installed to establish a baseline.
     - name: Run CTS cts-traffic baseline
       working-directory: ${{ github.workspace }}\cts-traffic
@@ -206,11 +215,15 @@ jobs:
         $profile = 0
         if ("${{inputs.profile}}" -eq "true") { $profile = 1 }
         $url = "https://raw.githubusercontent.com/microsoft/bpf_performance/main/scripts/two-machine-perf.ps1"
-        if ("${{inputs.tcp_ip_tracing}}" -eq "true") { wpr -start ${{ github.workspace }}\.github\workflows\tcpip.wprp }
         iex "& { $(irm $url) } -CpuProfile $profile"
-        if ("${{inputs.tcp_ip_tracing}}" -eq "true") { wpr -stop ${{ github.workspace }}\ETL\tcpip_baseline.etl }
         if ($Profile) { Move-Item -Path ${{ github.workspace }}\cts-traffic\cts_traffic_send.etl -NewName "${{ github.workspace }}\etl\cts_traffic_send_baseline.etl"}
         if ($Profile) { Rename-Item -Path ${{ github.workspace }}\cts-traffic\cts_traffic_recv.etl -NewName "${{ github.workspace }}\etl\cts_traffic_recv_baseline.etl" }
+        dir ${{ github.workspace }}\etl
+
+    - name: Stop TCPIP tracing - Baseline
+      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      run: |
+        wpr -stop ${{ github.workspace }}\ETL\tcpip_baseline.etl
 
     # The resulting CSV file's header is updated to match the format produced by the BPF performance tests.
     # The "Average Duration (ns)" column is the metric of interest.
@@ -244,6 +257,15 @@ jobs:
         bpftool prog show
         Test-Connection -ComputerName netperf-peer -Count 1 -Ping
 
+    - name: Start TCPIP tracing - XDP
+      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      run: |
+        Get-PSDrive -PSProvider FileSystem
+        wpr -cancel; $global:LASTEXITCODE = 0
+        if (Test-Path "tcpip.wprp") { Remove-Item -Force "tcpip.wprp" }
+        Invoke-WebRequest -uri "https://raw.githubusercontent.com/microsoft/netperf/main/.github/workflows/tcpip.wprp" -OutFile "tcpip.wprp"
+        wpr -start tcpip.wprp -filemode
+
     # Run CTS traffic with XDP installed to measure the impact of XDP on performance.
     - name: Run CTS cts-traffic xdp
       working-directory: ${{ github.workspace }}\cts-traffic
@@ -253,9 +275,16 @@ jobs:
         $profile = 0
         if ("${{inputs.profile}}" -eq "true") { $profile = 1 }
         $url = "https://raw.githubusercontent.com/microsoft/bpf_performance/main/scripts/two-machine-perf.ps1"
+        if (Test-Path "tcpip.wprp") { Remove-Item -Force "tcpip.wprp" }
+        Invoke-WebRequest -uri "https://raw.githubusercontent.com/microsoft/netperf/main/.github/workflows/tcpip.wprp" -OutFile "tcpip.wprp"
         if ("${{inputs.tcp_ip_tracing}}" -eq "true") { wpr -start ${{ github.workspace }}\.github\workflows\tcpip.wprp }
         iex "& { $(irm $url) } -CpuProfile $profile"
         if ("${{inputs.tcp_ip_tracing}}" -eq "true") { wpr -stop ${{ github.workspace }}\ETL\tcpip_xdp.etl }
+
+    - name: Stop TCPIP tracing - Baseline
+      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      run: |
+        wpr -stop ${{ github.workspace }}\ETL\tcpip_baseline.etl
 
     - name: Copy ETL files to ETL folder
       run: |


### PR DESCRIPTION
This pull request mainly introduces TCP/IP tracing capabilities to the GitHub Actions workflows `cts_traffic.yml` and `ebpf.yml`. It allows the user to optionally enable TCP/IP tracing by providing an input parameter. The changes also involve some cleanup operations and modifications to the job matrix configuration in `cts_traffic.yml`.

Here are the key changes:

TCP/IP Tracing:

* [`.github/workflows/cts_traffic.yml`](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213R17-R21): Added a new input parameter `tcp_ip_tracing` for enabling TCP/IP tracing.
* `.github/workflows/cts_traffic.yml` and `.github/workflows/ebpf.yml`: Added steps to start TCP/IP tracing if the `tcp_ip_tracing` input parameter is true, and to stop the tracing and move the resulting ETL files to the appropriate directory [[1]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213R87-R94) [[2]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213R103-R114) [[3]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bR201-R208) [[4]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL209-R226) [[5]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bR260-R268) [[6]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bR278-R288).

Cleanup Operations:

* `.github/workflows/cts_traffic.yml` and `.github/workflows/ebpf.yml`: Added a step to remove all items in the current directory at the start of the workflow [[1]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213R67) [[2]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bR106).

Job Matrix Configuration:

* [`.github/workflows/cts_traffic.yml`](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L49-R55): Commented out some configurations in the job matrix.

Artifact Upload:

* [`.github/workflows/cts_traffic.yml`](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L104-R124): Changed the condition for the ETL artifact upload to also include the `tcp_ip_tracing` input parameter.