### PR TITLE
Capture pktmon counters before and after running tests

### DIFF
--- a/.github/workflows/cts_traffic.yml
+++ b/.github/workflows/cts_traffic.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: false
         type: boolean
+      duration:
+        description: 'Duration of the test in seconds'
+        required: false
+        default: 60
+        type: number
 
   pull_request:
     branches:
@@ -84,8 +89,14 @@ jobs:
         name: "cts-traffic Release"
         path: ${{ github.workspace }}\cts-traffic
 
+    - name: Capture pktmon counters - start
+      run: |
+        pktmon stop
+        pktmon start --counters-only
+        pktmon counters -t all -z -i --json | Out-File -FilePath ${{ github.workspace }}\cts-traffic\pktmon_counters_start.json
+
     - name: Start TCPIP tracing
-      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      if: inputs.tcp_ip_tracing == true
       run: |
         wpr -cancel 2>$null; $global:LASTEXITCODE = 0
         if (Test-Path "tcpip.wprp") { Remove-Item -Force "tcpip.wprp" }
@@ -98,12 +109,17 @@ jobs:
         $profile = 0
         if ("${{inputs.profile}}" -eq "true") { $profile = 1 }
         $url = "https://raw.githubusercontent.com/microsoft/bpf_performance/main/scripts/two-machine-perf.ps1"
-        iex "& { $(irm $url) } -CpuProfile $profile"
+        iex "& { $(irm $url) } -CpuProfile $profile -Duration ${{inputs.duration}}"
 
     - name: Stop TCPIP tracing
-      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      if: inputs.tcp_ip_tracing == true
       run: |
         wpr -stop ${{ github.workspace }}\ETL\tcpip.etl
+
+    - name: Capture pktmon counters - end
+      run: |
+        pktmon counters -t all -z -i --json | Out-File -FilePath ${{ github.workspace }}\cts-traffic\pktmon_counters_end.json
+        pktmon stop
 
     - name: Move ETL files to ETLfolder 
       working-directory: ${{ github.workspace }}\cts-traffic
@@ -121,11 +137,18 @@ jobs:
         path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv 
 
     - name: Upload ETL
-      if: ${{ github.event.inputs.profile }} || ${{ github.event.inputs.tcp_ip_tracing }}
+      if: inputs.profile == true || inputs.tcp_ip_tracing == true
       uses: actions/upload-artifact@v2
       with:
         name: cts_traffic_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}_ETL
         path: ${{ github.workspace }}\ETL\*.etl
+
+    - name: Upload pktmon counters
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: cts_traffic_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}_pktmon_counters
+        path: ${{ github.workspace }}\cts-traffic\pktmon_counters_*.json
 
     - name: Cleanup workspace
       if: always()

--- a/.github/workflows/cts_traffic.yml
+++ b/.github/workflows/cts_traffic.yml
@@ -20,9 +20,9 @@ on:
         default: false
         type: boolean
       duration:
-        description: 'Duration of the test in seconds'
+        description: 'Duration of the test in milliseconds'
         required: false
-        default: 60
+        default: 60000
         type: number
 
   pull_request:
@@ -107,9 +107,10 @@ jobs:
       working-directory: ${{ github.workspace }}\cts-traffic
       run: |
         $profile = 0
+        $duration = ${{inputs.duration}}
         if ("${{inputs.profile}}" -eq "true") { $profile = 1 }
         $url = "https://raw.githubusercontent.com/microsoft/bpf_performance/main/scripts/two-machine-perf.ps1"
-        iex "& { $(irm $url) } -CpuProfile $profile -Duration ${{inputs.duration}}"
+        iex "& { $(irm $url) } -CpuProfile $profile -Duration $duration"
 
     - name: Stop TCPIP tracing
       if: inputs.tcp_ip_tracing == true
@@ -120,6 +121,10 @@ jobs:
       run: |
         pktmon counters -t all -z -i --json | Out-File -FilePath ${{ github.workspace }}\cts-traffic\pktmon_counters_end.json
         pktmon stop
+
+    - name: Query NIC discard counters
+      run: |
+        get-counter "\Network Adapter(*)\packets received discarded"
 
     - name: Move ETL files to ETLfolder 
       working-directory: ${{ github.workspace }}\cts-traffic

--- a/.github/workflows/cts_traffic.yml
+++ b/.github/workflows/cts_traffic.yml
@@ -126,6 +126,10 @@ jobs:
       run: |
         get-counter "\Network Adapter(*)\packets received discarded"
 
+    - name: Query RSS settings
+      run: |
+        Get-NetAdapterRss
+
     - name: Move ETL files to ETLfolder 
       working-directory: ${{ github.workspace }}\cts-traffic
       run: |

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -224,9 +224,10 @@ jobs:
       run: |
         dir .
         $profile = 0
+        $duration = ${{inputs.duration}}
         if ("${{inputs.profile}}" -eq "true") { $profile = 1 }
         $url = "https://raw.githubusercontent.com/microsoft/bpf_performance/main/scripts/two-machine-perf.ps1"
-        iex "& { $(irm $url) } -CpuProfile $profile -Duration ${{inputs.duration}}"
+        iex "& { $(irm $url) } -CpuProfile $profile -Duration $duration"
         if ($Profile) { Move-Item -Path ${{ github.workspace }}\cts-traffic\cts_traffic_send.etl -NewName "${{ github.workspace }}\etl\cts_traffic_send_baseline.etl"}
         if ($Profile) { Rename-Item -Path ${{ github.workspace }}\cts-traffic\cts_traffic_recv.etl -NewName "${{ github.workspace }}\etl\cts_traffic_recv_baseline.etl" }
         dir ${{ github.workspace }}\etl
@@ -295,12 +296,13 @@ jobs:
       run: |
         dir .
         $profile = 0
+        $duration = ${{inputs.duration}}
         if ("${{inputs.profile}}" -eq "true") { $profile = 1 }
         $url = "https://raw.githubusercontent.com/microsoft/bpf_performance/main/scripts/two-machine-perf.ps1"
         if (Test-Path "tcpip.wprp") { Remove-Item -Force "tcpip.wprp" }
         Invoke-WebRequest -uri "https://raw.githubusercontent.com/microsoft/netperf/main/.github/workflows/tcpip.wprp" -OutFile "tcpip.wprp"
         if ("${{inputs.tcp_ip_tracing}}" -eq "true") { wpr -start ${{ github.workspace }}\.github\workflows\tcpip.wprp }
-        iex "& { $(irm $url) } -CpuProfile $profile"
+        iex "& { $(irm $url) } -CpuProfile $profile -Duration $duration"
         if ("${{inputs.tcp_ip_tracing}}" -eq "true") { wpr -stop ${{ github.workspace }}\ETL\tcpip_xdp.etl }
 
     - name: Stop TCPIP tracing - Baseline

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: false
         type: boolean
+      duration:
+        description: 'Duration of the test in seconds'
+        required: false
+        default: 60
+        type: number
 
   pull_request:
     branches:
@@ -198,8 +203,14 @@ jobs:
         name: "cts-traffic Release"
         path: ${{ github.workspace }}\cts-traffic
 
+    - name: Capture pktmon counters - start - baseline
+      run: |
+        pktmon stop
+        pktmon start --counters-only
+        pktmon counters -t all -z -i --json | Out-File -FilePath ${{ github.workspace }}\cts-traffic\pktmon_counters_baseline_start.json
+
     - name: Start TCPIP tracing - Baseline
-      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      if: inputs.tcp_ip_tracing == true
       run: |
         wpr -cancel 2>$null; $global:LASTEXITCODE = 0
         if (Test-Path "tcpip.wprp") { Remove-Item -Force "tcpip.wprp" }
@@ -215,15 +226,20 @@ jobs:
         $profile = 0
         if ("${{inputs.profile}}" -eq "true") { $profile = 1 }
         $url = "https://raw.githubusercontent.com/microsoft/bpf_performance/main/scripts/two-machine-perf.ps1"
-        iex "& { $(irm $url) } -CpuProfile $profile"
+        iex "& { $(irm $url) } -CpuProfile $profile -Duration ${{inputs.duration}}"
         if ($Profile) { Move-Item -Path ${{ github.workspace }}\cts-traffic\cts_traffic_send.etl -NewName "${{ github.workspace }}\etl\cts_traffic_send_baseline.etl"}
         if ($Profile) { Rename-Item -Path ${{ github.workspace }}\cts-traffic\cts_traffic_recv.etl -NewName "${{ github.workspace }}\etl\cts_traffic_recv_baseline.etl" }
         dir ${{ github.workspace }}\etl
 
     - name: Stop TCPIP tracing - Baseline
-      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      if: inputs.tcp_ip_tracing == true
       run: |
         wpr -stop ${{ github.workspace }}\ETL\tcpip_baseline.etl
+
+    - name: Capture pktmon counters - end - baseline
+      run: |
+        pktmon counters -t all -z -i --json | Out-File -FilePath ${{ github.workspace }}\cts-traffic\pktmon_counters_baseline_end.json
+        pktmon stop
 
     # The resulting CSV file's header is updated to match the format produced by the BPF performance tests.
     # The "Average Duration (ns)" column is the metric of interest.
@@ -257,8 +273,14 @@ jobs:
         bpftool prog show
         Test-Connection -ComputerName netperf-peer -Count 1 -Ping
 
+    - name: Capture pktmon counters - start - xdp
+      run: |
+        pktmon stop
+        pktmon start --counters-only
+        pktmon counters -t all -z -i --json | Out-File -FilePath ${{ github.workspace }}\cts-traffic\pktmon_counters_xdp_start.json
+
     - name: Start TCPIP tracing - XDP
-      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      if: inputs.tcp_ip_tracing == true
       run: |
         Get-PSDrive -PSProvider FileSystem
         wpr -cancel; $global:LASTEXITCODE = 0
@@ -282,9 +304,14 @@ jobs:
         if ("${{inputs.tcp_ip_tracing}}" -eq "true") { wpr -stop ${{ github.workspace }}\ETL\tcpip_xdp.etl }
 
     - name: Stop TCPIP tracing - Baseline
-      if: ${{ github.event.inputs.tcp_ip_tracing }}
+      if: inputs.tcp_ip_tracing == true
       run: |
         wpr -stop ${{ github.workspace }}\ETL\tcpip_baseline.etl
+
+    - name: Capture pktmon counters - end - xdp
+      run: |
+        pktmon counters -t all -z -i --json | Out-File -FilePath ${{ github.workspace }}\cts-traffic\pktmon_counters_baseline_end.json
+        pktmon stop
 
     - name: Copy ETL files to ETL folder
       run: |
@@ -353,18 +380,25 @@ jobs:
         path: ${{ github.workspace }}\bpf_performance\ebpf.csv
 
     - name: Upload CPU profile
-      if: ${{ inputs.profile == true }}
+      if: inputs.profile == true
       uses: actions/upload-artifact@v2
       with:
         name: CPU_Profile_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
         path: ETL
 
     - name: Upload TCPIP ETL
-      if: ${{ inputs.tcp_ip_tracing == true }}
+      if: inputs.tcp_ip_tracing == true
       uses: actions/upload-artifact@v2
       with:
         name: TCPIP_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
         path: ${{ github.workspace }}\ETL
+
+    - name: Upload pktmon counters
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: cts_traffic_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}_pktmon_counters
+        path: ${{ github.workspace }}\cts-traffic\pktmon_counters_*.json
 
     - name: Cleanup workspace
       if: always()


### PR DESCRIPTION
This pull request primarily modifies two GitHub workflow files: `cts_traffic.yml` and `ebpf.yml`. The changes include the addition of a new `duration` parameter, the introduction of packet monitor (pktmon) counter capturing, and simplification of condition checks for tracing and profiling. 

Addition of `duration` parameter:

* `.github/workflows/cts_traffic.yml` and `.github/workflows/ebpf.yml`: A new `duration` parameter has been added to the workflow inputs. This parameter is optional and defaults to 60 seconds. It determines the duration of the test in seconds. [[1]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213R22-R26) [[2]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bR28-R32)

Introduction of pktmon counter capturing:

* [`.github/workflows/cts_traffic.yml`](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213R92-R99): Pktmon counter capturing has been added at the start and end of the job. The counters are saved to JSON files and uploaded as artifacts. [[1]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213R92-R99) [[2]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L101-R123) [[3]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L124-R152)

Simplification of condition checks:

* `.github/workflows/cts_traffic.yml` and `.github/workflows/ebpf.yml`: The condition checks for `tcp_ip_tracing` and `profile` have been simplified. Instead of checking against `github.event.inputs`, the checks are now directly against `inputs`. [[1]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213R92-R99) [[2]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L101-R123) [[3]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L124-R152) [[4]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL202-R207) [[5]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL218-R229) [[6]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL261-R266) [[7]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL285-R290) [[8]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL356-R368)

In addition, the `two-machine-perf.ps1` script is now invoked with the `duration` parameter in both workflows. [[1]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L101-R123) [[2]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL218-R229)