### PR TITLE
Fix epoll build path

### DIFF
--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -212,7 +212,7 @@ jobs:
       run: echo "OS=$('${{runner.os}}'.ToLower())" >> $env:GITHUB_ENV
     - name: Download Linux XDP Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
-      if: ${{ matrix.io == 'xdp' && matrix.os == 'ubuntu-22.04' }}
+      if: ${{ matrix.os == 'ubuntu-22.04' }} # xdp build includes epoll io
       with:
         name: Release-${{env.OS}}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}${{ matrix.io == 'xdp' && '-UseXdp' || '' }}-Perf
         path: artifacts
@@ -224,7 +224,7 @@ jobs:
         path: artifacts
     - name: Download Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
-      if: ${{ matrix.io != 'wsk' && !( matrix.io == 'xdp' && matrix.os == 'ubuntu-22.04' ) }}
+      if: ${{ matrix.io != 'wsk' && matrix.os != 'ubuntu-22.04' ) }}
       with:
         name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
         path: artifacts


### PR DESCRIPTION
epoll artifact was not found because its feature is included with xdp build.