### PR TITLE
Disable xdp on ubuntu 22.04

### DIFF
--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -514,7 +514,6 @@ jobs:
         path: artifacts
     - name: Download Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
-      if: ${{ matrix.io != 'wsk' }}
       with:
         name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
         path: artifacts

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -158,6 +158,8 @@ jobs:
             tls: 'openssl'
           - os: 'ubuntu-22.04'
             tls: 'openssl3'
+          - os: 'ubuntu-24.04'
+            tls: 'openssl3'
             xdp: '-UseXdp'
     uses: microsoft/msquic/.github/workflows/build-reuse-unix.yml@main
     with:
@@ -509,7 +511,7 @@ jobs:
       run: echo "OS=$('${{runner.os}}'.ToLower())" >> $env:GITHUB_ENV
     - name: Download Linux XDP Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
-      if: ${{ matrix.os == 'ubuntu-22.04' }} # xdp build includes epoll io
+      if: ${{ matrix.os == 'ubuntu-24.04' }} # xdp build includes epoll io
       with:
         name: Release-${{env.OS}}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-UseXdp-Perf
         path: artifacts
@@ -521,7 +523,7 @@ jobs:
         path: artifacts
     - name: Download Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
-      if: ${{ matrix.os != 'ubuntu-22.04' }}
+      if: ${{ matrix.os != 'ubuntu-24.04' }}
       with:
         name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
         path: artifacts

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -158,9 +158,6 @@ jobs:
             tls: 'openssl'
           - os: 'ubuntu-22.04'
             tls: 'openssl3'
-          - os: 'ubuntu-24.04'
-            tls: 'openssl3'
-            xdp: '-UseXdp'
     uses: microsoft/msquic/.github/workflows/build-reuse-unix.yml@main
     with:
       os: ${{ matrix.os }}
@@ -509,12 +506,6 @@ jobs:
     - name: Lowercase runner.os
       shell: pwsh
       run: echo "OS=$('${{runner.os}}'.ToLower())" >> $env:GITHUB_ENV
-    - name: Download Linux XDP Artifacts
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
-      if: ${{ matrix.os == 'ubuntu-24.04' }} # xdp build includes epoll io
-      with:
-        name: Release-${{env.OS}}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-UseXdp-Perf
-        path: artifacts
     - name: Download Kernel Drivers
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       if: ${{ matrix.io == 'wsk' }}
@@ -523,7 +514,7 @@ jobs:
         path: artifacts
     - name: Download Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
-      if: ${{ matrix.os != 'ubuntu-24.04' }}
+      if: ${{ matrix.io != 'wsk' }}
       with:
         name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
         path: artifacts

--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -7,6 +7,5 @@
     { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp" },
     { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk" },
     { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll" },
-    { "env": "lab",   "os": "ubuntu-22.04", "arch": "x64", "tls": "openssl3", "io": "epoll" },
-    { "env": "lab",   "os": "ubuntu-22.04", "arch": "x64", "tls": "openssl3", "io": "xdp" }
+    { "env": "lab",   "os": "ubuntu-22.04", "arch": "x64", "tls": "openssl3", "io": "epoll" }
 ]


### PR DESCRIPTION
Ubuntu 22.04 stop using xdp as MsQuic drop support.