### PR TITLE
Run XDP using the main tag

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
     uses: microsoft/xdp-for-windows/.github/workflows/build.yml@main
     with:
-      ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
+      ref: 'main'
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       upload_artifacts: true


### PR DESCRIPTION
This pull request includes a small change to the `jobs` section in the `.github/workflows/ebpf.yml` file. The change simplifies the reference to the branch being built by hardcoding it to 'main'.

* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL86-R86): Changed the `ref` value from a dynamic expression to the hardcoded string 'main'.