### PR TITLE
Fix run_script syntax error

### DIFF
--- a/run-workflow.ps1
+++ b/run-workflow.ps1
@@ -27,7 +27,7 @@ param (
     [switch]$skipWaiting,
 
     [Parameter(Mandatory = $false)]
-    [string]$project = "",
+    [string]$project = ""
 )
 
 Set-StrictMode -Version 'Latest'


### PR DESCRIPTION
My original motivation for updating the run-script code:

**We were making 1000+ web requests to /runs/job,** because it is not guaranteed that github backend will update /runs with the latest queued runs.