### PR TITLE
Add a delay to give github backend time to update

### DIFF
--- a/run-workflow.ps1
+++ b/run-workflow.ps1
@@ -129,6 +129,9 @@ function Wait-ForRun {
 Write-Host "Triggering new workflow ($guid)..."
 Start-Workflow
 
+# Wait a bit for the github backend to update.
+Start-Sleep 10
+
 # Find the workflow run.
 Write-Host "Looking for workflow run..."
 $id = Get-RunId


### PR DESCRIPTION
To further prevent scenarios where we're making more API calls than necessary, add a slight delay to give github backend to update with the queued runs.