### PR TITLE
Allow callees to download artifacts from the caller.

### DIFF
--- a/.github/actions/download-caller-artifacts/action.yml
+++ b/.github/actions/download-caller-artifacts/action.yml
@@ -1,0 +1,35 @@
+name: "Download caller artifacts"
+description: "This action runs multiple steps as a composite action."
+inputs:
+  caller_id:
+    description: "The caller id to use for the download."
+    type: string
+    required: true
+  name:
+    description: "The name of the artifact to download."
+    type: string
+    required: true
+  path:
+    description: "The path to download the artifact to."
+    type: string
+    required: true
+runs:
+  using: "composite"
+  steps:
+  - name: Query for artifact
+    run: |
+      $github_headers = @{
+        "Accept" = "application/vnd.github+json"
+        "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
+        "X-GitHub-Api-Version" = "2022-11-28"
+      }
+      $github_url = "https://api.github.com/repos/microsoft/netperf/actions/runs/${{ inputs.caller_id }}/artifacts"
+      $response = Invoke-WebRequest -Uri $github_url -Headers $github_headers -Method Get
+      $artifact = $response.Content | ConvertFrom-Json | Where-Object { $_.name -eq ${{ inputs.name }} }
+      if ($artifact -eq $null) {
+        Write-Error "Artifact not found."
+        exit 1
+      }
+      $artifact_download_url = $artifact.url 
+      $response = Invoke-WebRequest -Uri $artifact_download_url -Headers $github_headers -Method Get -OutFile "${{ inputs.name }}.zip"
+      Write-Output "Artifact downloaded successfully!"

--- a/.github/workflows/lab-quic-callee.yml
+++ b/.github/workflows/lab-quic-callee.yml
@@ -17,6 +17,7 @@ jobs:
           echo "io: ${{ github.event.client_payload.io }}"
           echo "tls: ${{ github.event.client_payload.tls }}"
           echo "arch: ${{ github.event.client_payload.arch }}"
+          echo "caller id: ${{ github.event.client_payload.caller_id }}"
       - name: Upload current workflow ID (unique_env_str = this_workflow_id)
         run: |
           $header = @{
@@ -31,65 +32,18 @@ jobs:
             Write-Host "Failed to alert observer VM online: $_"
             exit 1
           }
-  
-  #
-  # Build Jobs
-  #
-
-  build-windows:
-    name: Build WinUser
-    needs: [netperf-register]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ['windows-2022']
-        tls: [schannel] # , openssl, openssl3]
-    uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
-    with:
-      os: ${{ matrix.os }}
-      tls: ${{ matrix.tls }}
-      build: -Perf
-      ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
-
-  build-windows-kernel:
-    name: Build WinKernel
-    needs: []
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ['windows-2022']
-    uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml@main
-    with:
-      os: ${{ matrix.os }}
-      ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
-
-  build-unix:
-    name: Build Unix
-    needs: []
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: 'ubuntu-20.04'
-            tls: 'openssl'
-          - os: 'ubuntu-22.04'
-            tls: 'openssl3'
-    uses: microsoft/msquic/.github/workflows/build-reuse-unix.yml@main
-    with:
-      os: ${{ matrix.os }}
-      tls: ${{ matrix.tls }}
-      xdp: ${{ matrix.xdp }}
-      build: -Perf
-      ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
-  
 
   run-secnetperf:
     name: secnetperf
-    needs: [build-windows, build-windows-kernel, build-unix]
+    needs: [netperf-register]
     runs-on:
     - self-hosted
     - ${{ github.event.client_payload.assigned_runner }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      with:
+        path: netperfrepo
     - name: Checkout microsoft/msquic
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       with:
@@ -99,14 +53,16 @@ jobs:
       shell: pwsh
       run: echo "OS=$('${{runner.os}}'.ToLower())" >> $env:GITHUB_ENV
     - name: Download Kernel Drivers
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: ./netperfrepo/.github/actions/download-caller-artifacts
       if: ${{ github.event.client_payload.io == 'wsk' }}
       with:
+        caller_id: ${{ github.event.client_payload.caller_id }}
         name: Release-winkernel-${{ github.event.client_payload.os == 'windows-2025' && 'windows-2022' || github.event.client_payload.os }}-${{ github.event.client_payload.arch }}-${{ github.event.client_payload.tls }}
         path: artifacts
     - name: Download Artifacts
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: ./netperfrepo/.github/actions/download-caller-artifacts
       with:
+        caller_id: ${{ github.event.client_payload.caller_id }}
         name: Release-${{env.OS}}-${{ github.event.client_payload.os == 'windows-2025' && 'windows-2022' || github.event.client_payload.os }}-${{ github.event.client_payload.arch }}-${{ github.event.client_payload.tls }}-Perf
         path: artifacts
     - name: Download Regression.json file


### PR DESCRIPTION
According to my design: https://github.com/microsoft/netperf/blob/main/docs/stateless-lab-vms-image.jpg

The caller (main workflow) dispatches child workflows to run.

Originally, I had in mind the child would re-build all the artifacts.

However, seeing as this will inevitably lead to super long jobs, this PR makes it so child workflows references build jobs from the parent instead. 