### PR TITLE
Switch to latest upload/download artifact tasks

### DIFF
--- a/.github/workflows/cts_traffic.yml
+++ b/.github/workflows/cts_traffic.yml
@@ -79,7 +79,7 @@ jobs:
         Add-MpPreference -ExclusionPath ${{ github.workspace }}
 
     - name: Download cts-traffic
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@v4
       with:
         name: "cts-traffic Release"
         path: ${{ github.workspace }}\cts-traffic
@@ -115,14 +115,14 @@ jobs:
 
     - name: Upload CTS cts-traffic results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: cts_traffic_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
         path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv 
 
     - name: Upload ETL
       if: ${{ github.event.inputs.profile }} || ${{ github.event.inputs.tcp_ip_tracing }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: cts_traffic_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}_ETL
         path: ${{ github.workspace }}\ETL\*.etl

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -156,7 +156,7 @@ jobs:
         echo "C:\Program Files\GitHub CLI" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Download ebpf-for-windows
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@v4
       with:
         name: "ebpf-for-windows - MSI installer (none_NativeOnlyRelease)"
         path: ${{ github.workspace }}\bpf_performance
@@ -170,13 +170,13 @@ jobs:
 
     - name: Upload ebpf-for-windows logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ebpf-for-windows-logs
         path: ${{ github.workspace }}\bpf_performance\install.log
 
     - name: Download xdp-for-windows
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@v4
       with:
         name: "bin_Release_x64"
         path: ${{ github.workspace }}\xdp
@@ -215,7 +215,7 @@ jobs:
         Expand-Archive -Path build-Release-windows-2022.zip -DestinationPath .
 
     - name: Download cts-traffic
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@v4
       with:
         name: "cts-traffic Release"
         path: ${{ github.workspace }}\cts-traffic
@@ -259,7 +259,7 @@ jobs:
 
     - name: Upload CTS cts-traffic results baseline
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: cts_traffic_baseline_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
         path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv 
@@ -331,7 +331,7 @@ jobs:
 
     - name: Upload CTS cts-traffic results xdp
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: cts_traffic_xdp_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
         path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv 
@@ -351,7 +351,7 @@ jobs:
 
     - name: Upload BPF performance test results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: bpf_performance_native_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
         path: ${{ github.workspace }}\bpf_performance\bpf_performance_native.csv
@@ -369,21 +369,21 @@ jobs:
 
     - name: Upload merged results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ebpf_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
         path: ${{ github.workspace }}\bpf_performance\ebpf.csv
 
     - name: Upload CPU profile
       if: ${{ inputs.profile == true }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: CPU_Profile_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
         path: ETL
 
     - name: Upload TCPIP ETL
       if: ${{ inputs.tcp_ip_tracing == true }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: TCPIP_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
         path: ${{ github.workspace }}\ETL

--- a/.github/workflows/ebpf_dynamic_vm.yml
+++ b/.github/workflows/ebpf_dynamic_vm.yml
@@ -150,7 +150,7 @@ jobs:
         Start-Process -FilePath "vc_redist.x64.exe" -ArgumentList "/quiet /qn /norestart" -Wait -NoNewWindow
 
     - name: Download ebpf-for-windows
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@v4
       with:
         name: "ebpf-for-windows - MSI installer (none_NativeOnlyRelease)"
         path: ${{ github.workspace }}\bpf_performance
@@ -206,7 +206,7 @@ jobs:
         Expand-Archive -Path build-Release-windows-2022.zip -DestinationPath .
 
     - name: Download cts-traffic
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
+      uses: actions/download-artifact@v4
       with:
         name: "cts-traffic Release"
         path: ${{ github.workspace }}\cts-traffic
@@ -236,7 +236,7 @@ jobs:
 
     - name: Upload CTS cts-traffic results baseline
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: cts_traffic_baseline_${{ matrix.env }}_${{ matrix.os }}_${{ matrix.arch }}
         path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv 
@@ -290,7 +290,7 @@ jobs:
 
     - name: Upload CTS cts-traffic results xdp
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: cts_traffic_xdp_${{ matrix.env }}_${{ matrix.os }}_${{ matrix.arch }}
         path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv 
@@ -310,7 +310,7 @@ jobs:
 
     - name: Upload BPF performance test results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: bpf_performance_native_${{ matrix.env }}_${{ matrix.os }}_${{ matrix.arch }}
         path: ${{ github.workspace }}\bpf_performance\bpf_performance_native.csv
@@ -328,14 +328,14 @@ jobs:
 
     - name: Upload merged results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ebpf_${{ matrix.env }}_${{ matrix.os }}_${{ matrix.arch }}
         path: ${{ github.workspace }}\bpf_performance\ebpf.csv
 
     - name: Upload CPU profile
       if: ${{ inputs.profile == true }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: CPU_Profile_${{ matrix.env }}_${{ matrix.os }}_${{ matrix.arch }}
         path: ETL


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use the latest versions of the `download-artifact` and `upload-artifact` actions. This change ensures that the workflows are using the most up-to-date and maintained versions of these actions.

Updates to GitHub Actions workflow files:

* [`.github/workflows/cts_traffic.yml`](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L82-R82): Updated `download-artifact` action to `v4` and `upload-artifact` action to `v4` for downloading and uploading CTS traffic artifacts. [[1]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L82-R82) [[2]](diffhunk://#diff-2c206f286084e2f2a2cdc3d684f67639bc8971f39687ae820a23976da3d32213L118-R125)
* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL159-R159): Updated `download-artifact` action to `v4` and `upload-artifact` action to `v4` for various steps including downloading ebpf-for-windows, cts-traffic, and uploading logs and results. [[1]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL159-R159) [[2]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL173-R179) [[3]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL218-R218) [[4]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL262-R262) [[5]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL334-R334) [[6]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL354-R354) [[7]](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL372-R386)
* [`.github/workflows/ebpf_dynamic_vm.yml`](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fL153-R153): Updated `download-artifact` action to `v4` and `upload-artifact` action to `v4` for downloading ebpf-for-windows, cts-traffic, and uploading various test results and profiles. [[1]](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fL153-R153) [[2]](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fL209-R209) [[3]](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fL239-R239) [[4]](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fL293-R293) [[5]](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fL313-R313) [[6]](diffhunk://#diff-8aae889ec984d7b2b51b8ec3ce26d809b8d649170b185af76e87fc7a383ae58fL331-R338)