### PR TITLE
Add logging about the system the tests are being run on

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -131,6 +131,12 @@ jobs:
         New-item -ItemType Directory -Path ${{ github.workspace }}\cts-traffic
         New-item -ItemType Directory -Path ${{ github.workspace }}\ETL
 
+    - name: Log System information
+      run: |
+        Get-WmiObject -Class Win32_Processor | Select-Object -Property Name,NumberOfCores,NumberOfLogicalProcessors
+        Get-WmiObject -Class Win32_ComputerSystem | Select-Object -Property Manufacturer,Model,TotalPhysicalMemory
+        Get-WmiObject -Class Win32_OperatingSystem | Select-Object -Property Caption,Version,OSArchitecture
+
     # Install the latest anti-malware signatures for Windows Defender to prevent false positives.
     # Windows Defender incorrectly flags some of the test binaries as malware.
     - name: Download latest anti-malware signatures for Windows Defender


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ebpf.yml` file. The change adds a step to log system information during the workflow execution.

* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bR134-R139): Added a step to log system information, including details about the processor, computer system, and operating system.