### PR TITLE
Mark Ubuntu Scenarios As "Reliable"

### DIFF
--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -2,7 +2,7 @@
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Standard_F8s_v2", "in_staging_mode": "Due to lack of vCPU capacity for f-series VMs" },
-    { "env": "azure", "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll", "preferred_pool_sku": "Experimental_Boost4", "in_staging_mode": "Due to failures caused by UNIX CxPlat epoll problem" },
+    { "env": "azure", "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "iocp", "preferred_pool_sku": "Standard_F8s_v2", "in_staging_mode": "Due to lack of vCPU capacity for f-series VMs" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp", "preferred_pool_sku": "Standard_F8s_v2", "in_staging_mode": "Due to lack of vCPU capacity for f-series VMs" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Standard_F8s_v2", "in_staging_mode": "Due to lack of vCPU capacity for f-series VMs" },
@@ -12,6 +12,6 @@
     { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "iocp" },
     { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp" },
     { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk" },
-    { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll", "in_staging_mode": "Due to failures caused by UNIX CxPlat epoll problem" },
-    { "env": "lab",   "os": "ubuntu-22.04", "arch": "x64", "tls": "openssl3", "io": "epoll", "in_staging_mode": "Due to failures caused by UNIX CxPlat epoll problem" }
+    { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll" },
+    { "env": "lab",   "os": "ubuntu-22.04", "arch": "x64", "tls": "openssl3", "io": "epoll" }
 ]


### PR DESCRIPTION
Through various changes to the CxPlat PAL layer, it looks like the failures we were seeing with Ubuntu running Secnetperf has gone away.

This PR moves the Ubuntu scenarios out of the "staging" bucket into the "production" bucket.