### PR TITLE
File bug on workflow failure

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -186,7 +186,7 @@ jobs:
       run: |
           cd ${{ github.workspace }}\\xdp\x64_Release
           $CertFileName = 'xdp.cer'
-          Get-AuthenticodeSignature 'xdp-for-windows.${{env.XDP_VERSION}}.msi' | Select-Object -ExpandProperty SignerCertificate | Export-Certificate -Type CERT -FilePath $CertFileName
+          Get-AuthenticodeSignature 'xdp.sys' | Select-Object -ExpandProperty SignerCertificate | Export-Certificate -Type CERT -FilePath $CertFileName
           Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\root'
           Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher'
           $installPath = "${{ github.workspace }}\xdp\x64_release"

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -407,3 +407,56 @@ jobs:
         Update-MpSignature -Verbose
         Start-MpScan -ScanType QuickScan
 
+  # File a bug if the test fails.
+  create_or_update_issue:
+      needs: test
+      if: ${{ failure() }}
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+          if: ${{ github.event_name == 'repository_dispatch' }}
+          env:
+            TITLE: 'eBPF for Windows Performance Test Failed'
+            BODY: |
+              [Failed Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+              Test name - `eBPF for Windows Performance Test`
+            LABELS: bug
+
+          with:
+            script: |
+              const owner = process.env.GITHUB_REPOSITORY.split('/')[0]
+              const repo = process.env.GITHUB_REPOSITORY.split('/')[1]
+              const body = process.env.BODY;
+              const title = process.env.TITLE;
+              const labels = process.env.LABELS;
+              const label_array = labels ? labels.split(',') : [];
+              console.log(label_array);
+              // Get all issues that have these labels.
+              const opts = github.rest.issues.listForRepo.endpoint.merge({
+                ...context.issue,
+                state: 'open',
+                labels: label_array,
+              });
+              const issues = await github.paginate(opts);
+              // Look for an existing issue with the same title.
+              for (const issue of issues) {
+                if (issue.title === title) {
+                  console.log(`Updating issue ${title}`);
+                  await github.rest.issues.createComment({
+                    issue_number: issue.number,
+                    owner,
+                    repo,
+                    body,
+                  });
+                  return;
+                }
+              }
+              // Existing issue not found, create a new one.
+              console.log(`Creating issue ${title}`);
+              await github.rest.issues.create({
+                owner: owner,
+                repo: repo,
+                title: title,
+                body: body,
+                labels: label_array,
+              });


### PR DESCRIPTION
This pull request introduces a mechanism to automatically create or update a GitHub issue if a specific test fails in the `eBPF for Windows Performance Test` workflow. This enhancement aims to streamline the bug reporting process by automating issue creation and updates.

### Automation of Bug Reporting:

* **New Job for Issue Creation/Update**: Added a job named `create_or_update_issue` to the `.github/workflows/ebpf.yml` file. This job triggers when the `test` job fails and uses the `actions/github-script` action to either create a new issue or update an existing one with the same title. The issue includes a link to the failed run and is labeled as a bug.