### PR TITLE
disable ubuntu 22.04 runs

### DIFF
--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -12,6 +12,5 @@
     { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "iocp" },
     { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp" },
     { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk" },
-    { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll" },
-    { "env": "lab",   "os": "ubuntu-22.04", "arch": "x64", "tls": "openssl3", "io": "epoll" }
+    { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll" }
 ]


### PR DESCRIPTION
A member of our team inadvertently used one of our pipeline machines for their hackathon project.

This, in turn, broke Ubuntu 22.04 runs.

Resetting checkpoints doesn't solve the problem here, it looks like the physical machine itself was modified with.

Until this issue is solved, we are disabling Ubuntu 22.04 runs so future jobs will not get blocked.