### PR TITLE
Fix for update in xdp that switched from arch -> platform

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -192,13 +192,20 @@ jobs:
           $installPath = "${{ github.workspace }}\xdp\x64_release"
           Write-Output "xdp installPath: $installPath"
           Write-Output "Installing XDP for Windows"
-          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.${{env.XDP_VERSION}}.msi INSTALLFOLDER=$installPath /qn" -PassThru
+          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.${{env.XDP_VERSION}}.msi INSTALLFOLDER=$installPath /qn /log ${{ github.workspace }}\xdp\xdp_install.log" -PassThru
           if ($process.ExitCode -ne 0) { exit $process.ExitCode }
           Write-Output "XDP for Windows installed"
           sc.exe query xdp
           reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XdpEbpfEnabled /d 1 /t REG_DWORD /f
           sc.exe stop xdp
           sc.exe start xdp
+
+    - name: Upload ebpf-for-windows logs
+      if: always()
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      with:
+        name: ebpf-for-windows-logs
+        path: ${{ github.workspace }}\xdp\xdp_install.log
 
     - name: Download bpf_performance repository artifacts
       working-directory: ${{ github.workspace }}\bpf_performance

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -193,7 +193,7 @@ jobs:
           Write-Output "xdp installPath: $installPath"
           Write-Output "Installing XDP for Windows"
           $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.${{env.XDP_VERSION}}.msi INSTALLFOLDER=$installPath /qn /log ${{ github.workspace }}\xdp\xdp_install.log ADDLOCAL=ALL" -PassThru
-          if ($process.ExitCode -ne 0) { exit $process.ExitCode }
+          if ($process.ExitCode -ne 0) { Get-Content ${{ github.workspace }}\xdp\xdp_install.log; exit $process.ExitCode }
           Write-Output "XDP for Windows installed"
           sc.exe query xdp
           reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XdpEbpfEnabled /d 1 /t REG_DWORD /f

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -192,7 +192,7 @@ jobs:
           $installPath = "${{ github.workspace }}\xdp\x64_release"
           Write-Output "xdp installPath: $installPath"
           Write-Output "Installing XDP for Windows"
-          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.${{env.XDP_VERSION}}.msi INSTALLFOLDER=$installPath /qn /log ${{ github.workspace }}\xdp\xdp_install.log ADDLOCAL=ALL" -PassThru
+          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.x64.${{env.XDP_VERSION}}.msi INSTALLFOLDER=$installPath /qn /log ${{ github.workspace }}\xdp\xdp_install.log ADDLOCAL=ALL" -PassThru
           if ($process.ExitCode -ne 0) { Get-Content ${{ github.workspace }}\xdp\xdp_install.log; exit $process.ExitCode }
           Write-Output "XDP for Windows installed"
           sc.exe query xdp

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -192,7 +192,7 @@ jobs:
           $installPath = "${{ github.workspace }}\xdp\x64_release"
           Write-Output "xdp installPath: $installPath"
           Write-Output "Installing XDP for Windows"
-          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.${{env.XDP_VERSION}}.msi INSTALLFOLDER=$installPath /qn /log ${{ github.workspace }}\xdp\xdp_install.log" -PassThru
+          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i xdp-for-windows.${{env.XDP_VERSION}}.msi INSTALLFOLDER=$installPath /qn /log ${{ github.workspace }}\xdp\xdp_install.log ADDLOCAL=ALL" -PassThru
           if ($process.ExitCode -ne 0) { exit $process.ExitCode }
           Write-Output "XDP for Windows installed"
           sc.exe query xdp
@@ -200,11 +200,11 @@ jobs:
           sc.exe stop xdp
           sc.exe start xdp
 
-    - name: Upload ebpf-for-windows logs
+    - name: Upload xdp-for-windows logs
       if: always()
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
-        name: ebpf-for-windows-logs
+        name: xdp-for-windows-logs
         path: ${{ github.workspace }}\xdp\xdp_install.log
 
     - name: Download bpf_performance repository artifacts

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -85,7 +85,7 @@ jobs:
     with:
       ref: 'main'
       os: ${{ matrix.os }}
-      arch: ${{ matrix.arch }}
+      platform: ${{ matrix.arch }}
       upload_artifacts: true
 
   build_cts_traffic:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ebpf.yml` file. The change updates the `arch` parameter to `platform` within the `jobs` section.

* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL88-R88): Updated `arch` parameter to `platform` for better clarity and consistency.