### PR TITLE
Fix breaking change in xdp-for-windows repo

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -86,7 +86,7 @@ jobs:
       ref: 'main'
       os: ${{ matrix.os }}
       platform: ${{ matrix.arch }}
-      upload_artifacts: true
+      artifact_path: "bin_Release_x64"
 
   build_cts_traffic:
     name: Build cts-traffic test tool


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/ebpf.yml` file to specify the path for build artifacts instead of using a boolean flag.

Workflow configuration update:

* [`.github/workflows/ebpf.yml`](diffhunk://#diff-83bd19d37db58d4aaf751eefee7f644a2883940593c66b9254da4b4016ca6c0bL89-R89): Changed the `upload_artifacts` flag to specify the `artifact_path` as `"bin_Release_x64"`.