### PR TITLE
Leverage Get-VMNetworkAdapter to differentiate VM state

### DIFF
--- a/.github/workflows/operate-lab.yml
+++ b/.github/workflows/operate-lab.yml
@@ -72,10 +72,11 @@ jobs:
         run: |
           $vmName = "netperf-${{ matrix.os }}-server"
           Start-VM -Name $vmName
-          while ((Get-VM -Name $vmName).State -ne "Running") {
+          while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
             Write-Host "Waiting for VM to be online..."
-            Start-Sleep -Seconds 10
+            Start-Sleep -Seconds 5
           }
+          Start-Sleep 10
           $headers = @{
             "secret" = "${{ secrets.NETPERF_SYNCER_SECRET }}"
           }

--- a/.github/workflows/reset-child-machine.yml
+++ b/.github/workflows/reset-child-machine.yml
@@ -31,9 +31,18 @@ jobs:
         run: |
           $vmName = "netperf-${{ github.event.client_payload.os }}-client"
           Start-VM -Name $vmName
-          while ((Get-VM -Name $vmName).State -ne "Running") {
+          while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
             Write-Host "Waiting for VM to be online..."
-            Start-Sleep -Seconds 10
+            Start-Sleep -Seconds 5
+          }
+          Start-Sleep 10
+          $username = "${{ secrets.VM_DUMMY_USERNAME }}"
+          $password = "${{ secrets.VM_DUMMY_PASSWORD }}"
+          $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
+          $credential = New-Object System.Management.Automation.PSCredential ($username, $securePassword)
+          Invoke-Command -VMName $vmName -Credential $credential -ScriptBlock {
+            Start-Service -Name "actions.runner.*"
+            Get-Service -Name "actions.runner.*"
           }
           $headers = @{
             "secret" = "${{ secrets.NETPERF_SYNCER_SECRET }}"


### PR DESCRIPTION
Previously, we were using Get-VM.state to see if the VM is online. 

This, actually, was not the case. A VM can be running but not online.

So we will use the Get-VMNetworkAdapter instead.