### PR TITLE
Add auxiliary workflow

### DIFF
--- a/.github/workflows/reset-parent-or-child.yml
+++ b/.github/workflows/reset-parent-or-child.yml
@@ -35,24 +35,3 @@ jobs:
               Start-Sleep -Seconds 5
             }
             Start-Sleep 10
-            $username = "${{ secrets.VM_DUMMY_USERNAME }}"
-            $password = "${{ secrets.VM_DUMMY_PASSWORD }}"
-            $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
-            $credential = New-Object System.Management.Automation.PSCredential ($username, $securePassword)
-            Invoke-Command -VMName $vmName -Credential $credential -ScriptBlock {
-              Start-Service -Name "actions.runner.*"
-              Get-Service -Name "actions.runner.*"
-            }
-            $headers = @{
-              "secret" = "${{ secrets.NETPERF_SYNCER_SECRET }}"
-            }
-            $key = "${{ github.event.client_payload.unique_env_str }}_child_reset_done"
-            $value = whoami
-            $api = "https://netperfapi.azurewebsites.net/setkeyvalue?key=$key&value=$value"
-
-            try {
-              Invoke-WebRequest -Uri $api -Headers $headers -Method Post
-            } catch {
-              Write-Host "Failed to alert observer child reset done: $_"
-              exit 1
-            }

--- a/.github/workflows/reset-parent-or-child.yml
+++ b/.github/workflows/reset-parent-or-child.yml
@@ -1,0 +1,58 @@
+name: reset-parent-or-child
+
+on:
+  workflow_dispatch:
+    inputs:
+      parent-or-child:
+        description: "Lab jobs to observe"
+        required: true
+        type: string
+      vm-name:
+        description: "The name of the VM to reset"
+        default: "netperf-windows-2022-client"
+        required: true
+        type: string
+
+jobs:
+    do-reset-manual:
+      name: Reset parent or child Machine
+      runs-on:
+        - self-hosted
+        - ${{ inputs.parent-or-child }}
+      steps:
+        - name: RESET STATE (parent or child)
+          run: |
+            # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
+            $vmName = "${{ inputs.vm-name }}"
+            $checkPointName = "LATEST"
+            Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
+        - name: Start VM, wait for online status, alert observer.
+          run: |
+            $vmName = "${{ inputs.vm-name }}"
+            Start-VM -Name $vmName
+            while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
+              Write-Host "Waiting for VM to be online..."
+              Start-Sleep -Seconds 5
+            }
+            Start-Sleep 10
+            $username = "${{ secrets.VM_DUMMY_USERNAME }}"
+            $password = "${{ secrets.VM_DUMMY_PASSWORD }}"
+            $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
+            $credential = New-Object System.Management.Automation.PSCredential ($username, $securePassword)
+            Invoke-Command -VMName $vmName -Credential $credential -ScriptBlock {
+              Start-Service -Name "actions.runner.*"
+              Get-Service -Name "actions.runner.*"
+            }
+            $headers = @{
+              "secret" = "${{ secrets.NETPERF_SYNCER_SECRET }}"
+            }
+            $key = "${{ github.event.client_payload.unique_env_str }}_child_reset_done"
+            $value = whoami
+            $api = "https://netperfapi.azurewebsites.net/setkeyvalue?key=$key&value=$value"
+
+            try {
+              Invoke-WebRequest -Uri $api -Headers $headers -Method Post
+            } catch {
+              Write-Host "Failed to alert observer child reset done: $_"
+              exit 1
+            }


### PR DESCRIPTION
To support maintenance of our current infrastructure while we transition to a stateless lab, 

having to RDP and manually do a manual reset a MAJOR hassle.

This PR adds a helper workflow that will do the reset for you so you don't have to RDP into the lab machine.