### PR TITLE
Stabilize netperf

### DIFF
--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -311,7 +311,7 @@ jobs:
       shell: pwsh
     - name: Run secnetperf
       shell: pwsh
-      timeout-minutes: 40
+      timeout-minutes: 50
       run: |
           $env:netperf_remote_powershell_supported = $true
 

--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -9,8 +9,5 @@
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk" },
-    { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "iocp" },
-    { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp" },
-    { "env": "lab",   "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk" },
     { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll" }
 ]


### PR DESCRIPTION
Recently, a max RPS test was added, which caused some lab machines to become flaky.

Perhaps this is because of the large number of logical CPUs on the lab machine causing secnetperf max RPS to hang, or some other bug. 

Regardless, we should increase the timeout on the lab jobs and disable the static WS2025 lab machines in favor of a stateless lab setup. 

Additionally, perf data is currently being dashboarded for WS2025 on Azure only. We save perf data for WS2025 lab, but do not dashboard that. Therefore, let's disable that scenario until we figure out the bug with max RPS on lab and update the dashboard.