### PR TITLE
Increase timeout for netperf jobs

### DIFF
--- a/run-workflow.ps1
+++ b/run-workflow.ps1
@@ -116,7 +116,7 @@ function Get-RunStatus {
 
 function Wait-ForRun {
     param([string]$id)
-    for ($i = 0; $i -lt 120; $i++) { # 120 * 30 sec = 1 hour
+    for ($i = 0; $i -lt 240; $i++) { # 240 * 30 sec = 2 hours
         if (Get-RunStatus $id) {
             return
         }

--- a/run-workflow.ps1
+++ b/run-workflow.ps1
@@ -116,7 +116,7 @@ function Get-RunStatus {
 
 function Wait-ForRun {
     param([string]$id)
-    for ($i = 0; $i -lt 240; $i++) { # 240 * 30 sec = 2 hours
+    for ($i = 0; $i -lt 300; $i++) { # 300 * 30 sec = 2.5 hours
         if (Get-RunStatus $id) {
             return
         }


### PR DESCRIPTION
From adding the recent max RPS test, we are finding that jobs are taking much longer than expected.

To decrease the number of false positive failures, let's increase the timeout we enforce.