### PR TITLE
All windows 2022 runners should have test signing on

### DIFF
--- a/.github/workflows/prepare-matrix.ps1
+++ b/.github/workflows/prepare-matrix.ps1
@@ -18,7 +18,7 @@ $FullJson = @()
 
 foreach ($entry in $MatrixJson) {
     if ($entry.env -match "azure") {
-        $Windows2022Pool = "netperf-boosted-windows-pool" # NOTE: This pool is using experimental boost SKUs.
+        $Windows2022Pool = "netperf-actual-boosted-winprerelease" # TODO: "boost-prerelease" name is misleading. Change it to be "boosted-windows-2022"
         $Ubuntu2004Pool = "netperf-boosted-linux-pool" # NOTE: This pool is using experimental boost SKUs.
         $Windows2025Pool = "netperf-boosted-windows-prerelease-pool" # NOTE: This pool is using f-series SKUs.
         $client = $entry.PSObject.Copy()
@@ -29,9 +29,6 @@ foreach ($entry in $MatrixJson) {
             if ($entry.preferred_pool_sku -eq "Standard_F8s_v2") {
                 $Windows2022Pool = "netperf-f-series-windows-2022"
                 $Ubuntu2004Pool = "netperf-f-series-ubuntu-20.04"
-            }
-            if ($entry.preferred_pool_sku -eq "Experimental_Boost4_With_Testsigning") {
-                $Windows2022Pool = "netperf-actual-boosted-winprerelease"
             }
         }
 
@@ -78,13 +75,13 @@ foreach ($entry in $MatrixJson) {
         $labclient | Add-Member -MemberType NoteProperty -Name "remote_powershell_supported" -Value 'TRUE'
         $labclient | Add-Member -MemberType NoteProperty -Name "role" -Value "client"
         $labclient | Add-Member -MemberType NoteProperty -Name "env_str" -Value $env_str
-        
+
         if ("in_staging_mode" -in $entry.PSObject.Properties.Name) {
             $labclient | Add-Member -MemberType NoteProperty -Name "optional" -Value 'TRUE'
         } else {
             $labclient | Add-Member -MemberType NoteProperty -Name "optional" -Value 'FALSE'
         }
-        
+
         $LabJsonStateless += $labclient
         $FullJson += $labclient
     } elseif ($entry.env -match "lab") {

--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -1,7 +1,7 @@
 [
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp", "preferred_pool_sku": "Experimental_Boost4" },
-    { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4_With_Testsigning" },
+    { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "iocp", "preferred_pool_sku": "Standard_F8s_v2", "in_staging_mode": "Due to lack of vCPU capacity for f-series VMs" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp", "preferred_pool_sku": "Standard_F8s_v2", "in_staging_mode": "Due to lack of vCPU capacity for f-series VMs" },


### PR DESCRIPTION
In earlier iterations of netperf, we've had to work around some limitations due to test signing not available in Windows Experimental Boost runners. 

The Azure ES teams has made some strides in this area to allow test signing.

Let's adapt accordingly.

Testing:

CI. 