### PR TITLE
Improve usability of RESET_PARENT_CHILD workflow

### DIFF
--- a/.github/workflows/reset-parent-or-child.yml
+++ b/.github/workflows/reset-parent-or-child.yml
@@ -35,21 +35,21 @@ jobs:
         - self-hosted
         - ${{ matrix.vec.parent-or-child }}
       steps:
-        - name: RESET STATE (parent or child)
-          run: |
-            # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
-            $vmName = "${{ matrix.vec.vm-name }}"
-            $checkPointName = "LATEST"
-            Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
-        - name: Start VM, wait for online status, alert observer.
-          run: |
-            $vmName = "${{ matrix.vec.vm-name }}"
-            Start-VM -Name $vmName
-            while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
-              Write-Host "Waiting for VM to be online..."
-              Start-Sleep -Seconds 5
-            }
-            Start-Sleep 10
+      - name: RESET STATE (parent or child)
+        run: |
+          # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
+          $vmName = "${{ matrix.vec.vm-name }}"
+          $checkPointName = "LATEST"
+          Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
+      - name: Start VM, wait for online status, alert observer.
+        run: |
+          $vmName = "${{ matrix.vec.vm-name }}"
+          Start-VM -Name $vmName
+          while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
+            Write-Host "Waiting for VM to be online..."
+            Start-Sleep -Seconds 5
+          }
+          Start-Sleep 10
 
   do-reset-manual:
     name: Reset parent or child Machine
@@ -58,18 +58,18 @@ jobs:
       - self-hosted
       - ${{ inputs.parent-or-child }}
     steps:
-      - name: RESET STATE (parent or child)
-        run: |
-          # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
-          $vmName = "${{ inputs.vm-name }}"
-          $checkPointName = "LATEST"
-          Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
-      - name: Start VM, wait for online status, alert observer.
-        run: |
-          $vmName = "${{ inputs.vm-name }}"
-          Start-VM -Name $vmName
-          while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
-            Write-Host "Waiting for VM to be online..."
-            Start-Sleep -Seconds 5
-          }
-          Start-Sleep 10
+    - name: RESET STATE (parent or child)
+      run: |
+        # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
+        $vmName = "${{ inputs.vm-name }}"
+        $checkPointName = "LATEST"
+        Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
+    - name: Start VM, wait for online status, alert observer.
+      run: |
+        $vmName = "${{ inputs.vm-name }}"
+        Start-VM -Name $vmName
+        while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
+          Write-Host "Waiting for VM to be online..."
+          Start-Sleep -Seconds 5
+        }
+        Start-Sleep 10

--- a/.github/workflows/reset-parent-or-child.yml
+++ b/.github/workflows/reset-parent-or-child.yml
@@ -19,57 +19,57 @@ on:
           type: boolean
 
 jobs:
-    do-reset-all-active:
-      name: Reset all active lab machines
-      if: ${{ inputs.reset-all-active == true }}
-      strategy:
-        fail-fast: false
-        matrix:
-          vec: [
-            { parent-or-child: "parent=rr1-netperf-26\localadminuser",   vm-name: "netperf-windows-2022-client" },
-            { parent-or-child: "parent=rr1-netperf-25\localadminuser",   vm-name: "netperf-windows-2022-server" },
-            { parent-or-child: "parent=rr1-netperf-05\localadminuser",   vm-name: "netperf" },
-            { parent-or-child: "parent=rr1-netperf-10\localadminuser",   vm-name: "netperf" },
-          ]
-        runs-on:
-          - self-hosted
-          - ${{ matrix.vec.parent-or-child }}
-        steps:
-          - name: RESET STATE (parent or child)
-            run: |
-              # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
-              $vmName = "${{ matrix.vec.vm-name }}"
-              $checkPointName = "LATEST"
-              Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
-          - name: Start VM, wait for online status, alert observer.
-            run: |
-              $vmName = "${{ matrix.vec.vm-name }}"
-              Start-VM -Name $vmName
-              while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
-                Write-Host "Waiting for VM to be online..."
-                Start-Sleep -Seconds 5
-              }
-              Start-Sleep 10
-
-    do-reset-manual:
-      name: Reset parent or child Machine
-      if: ${{ inputs.reset-all-active == false }}
+  do-reset-all-active:
+    name: Reset all active lab machines
+    if: ${{ inputs.reset-all-active == true }}
+    strategy:
+      fail-fast: false
+      matrix:
+        vec: [
+          { parent-or-child: "parent=rr1-netperf-26\localadminuser",   vm-name: "netperf-windows-2022-client" },
+          { parent-or-child: "parent=rr1-netperf-25\localadminuser",   vm-name: "netperf-windows-2022-server" },
+          { parent-or-child: "parent=rr1-netperf-05\localadminuser",   vm-name: "netperf" },
+          { parent-or-child: "parent=rr1-netperf-10\localadminuser",   vm-name: "netperf" },
+        ]
       runs-on:
         - self-hosted
-        - ${{ inputs.parent-or-child }}
+        - ${{ matrix.vec.parent-or-child }}
       steps:
         - name: RESET STATE (parent or child)
           run: |
             # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
-            $vmName = "${{ inputs.vm-name }}"
+            $vmName = "${{ matrix.vec.vm-name }}"
             $checkPointName = "LATEST"
             Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
         - name: Start VM, wait for online status, alert observer.
           run: |
-            $vmName = "${{ inputs.vm-name }}"
+            $vmName = "${{ matrix.vec.vm-name }}"
             Start-VM -Name $vmName
             while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
               Write-Host "Waiting for VM to be online..."
               Start-Sleep -Seconds 5
             }
             Start-Sleep 10
+
+  do-reset-manual:
+    name: Reset parent or child Machine
+    if: ${{ inputs.reset-all-active == false }}
+    runs-on:
+      - self-hosted
+      - ${{ inputs.parent-or-child }}
+    steps:
+      - name: RESET STATE (parent or child)
+        run: |
+          # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
+          $vmName = "${{ inputs.vm-name }}"
+          $checkPointName = "LATEST"
+          Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
+      - name: Start VM, wait for online status, alert observer.
+        run: |
+          $vmName = "${{ inputs.vm-name }}"
+          Start-VM -Name $vmName
+          while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
+            Write-Host "Waiting for VM to be online..."
+            Start-Sleep -Seconds 5
+          }
+          Start-Sleep 10

--- a/.github/workflows/reset-parent-or-child.yml
+++ b/.github/workflows/reset-parent-or-child.yml
@@ -26,30 +26,30 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { parent-or-child: "parent=rr1-netperf-26\\localadminuser",   vm-name: "netperf-windows-2022-client" },
-          { parent-or-child: "parent=rr1-netperf-25\\localadminuser",   vm-name: "netperf-windows-2022-server" },
-          { parent-or-child: "parent=rr1-netperf-05\\localadminuser",   vm-name: "netperf" },
-          { parent-or-child: "parent=rr1-netperf-10\\localadminuser",   vm-name: "netperf" },
+          { parent-or-child: "parent=rr1-netperf-26\localadminuser",   vm-name: "netperf-windows-2022-client" },
+          { parent-or-child: "parent=rr1-netperf-25\localadminuser",   vm-name: "netperf-windows-2022-server" },
+          { parent-or-child: "parent=rr1-netperf-05\localadminuser",   vm-name: "netperf" },
+          { parent-or-child: "parent=rr1-netperf-10\localadminuser",   vm-name: "netperf" },
         ]
-      runs-on:
-        - self-hosted
-        - ${{ matrix.vec.parent-or-child }}
-      steps:
-      - name: RESET STATE (parent or child)
-        run: |
-          # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
-          $vmName = "${{ matrix.vec.vm-name }}"
-          $checkPointName = "LATEST"
-          Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
-      - name: Start VM, wait for online status, alert observer.
-        run: |
-          $vmName = "${{ matrix.vec.vm-name }}"
-          Start-VM -Name $vmName
-          while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
-            Write-Host "Waiting for VM to be online..."
-            Start-Sleep -Seconds 5
-          }
-          Start-Sleep 10
+    runs-on:
+      - self-hosted
+      - ${{ matrix.vec.parent-or-child }}
+    steps:
+    - name: RESET STATE (parent or child)
+      run: |
+        # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
+        $vmName = "${{ matrix.vec.vm-name }}"
+        $checkPointName = "LATEST"
+        Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
+    - name: Start VM, wait for online status, alert observer.
+      run: |
+        $vmName = "${{ matrix.vec.vm-name }}"
+        Start-VM -Name $vmName
+        while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
+          Write-Host "Waiting for VM to be online..."
+          Start-Sleep -Seconds 5
+        }
+        Start-Sleep 10
 
   do-reset-manual:
     name: Reset parent or child Machine

--- a/.github/workflows/reset-parent-or-child.yml
+++ b/.github/workflows/reset-parent-or-child.yml
@@ -5,12 +5,12 @@ on:
     inputs:
       parent-or-child:
         description: "Lab jobs to observe"
-        required: true
+        required: false
         type: string
       vm-name:
         description: "The name of the VM to reset"
         default: "netperf-windows-2022-client"
-        required: true
+        required: false
         type: string
       reset-all-active:
           description: "Resets all active lab machines"

--- a/.github/workflows/reset-parent-or-child.yml
+++ b/.github/workflows/reset-parent-or-child.yml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { parent-or-child: "parent=rr1-netperf-26\localadminuser",   vm-name: "netperf-windows-2022-client" },
-          { parent-or-child: "parent=rr1-netperf-25\localadminuser",   vm-name: "netperf-windows-2022-server" },
-          { parent-or-child: "parent=rr1-netperf-05\localadminuser",   vm-name: "netperf" },
-          { parent-or-child: "parent=rr1-netperf-10\localadminuser",   vm-name: "netperf" },
+          { parent-or-child: "parent=rr1-netperf-26\\localadminuser",   vm-name: "netperf-windows-2022-client" },
+          { parent-or-child: "parent=rr1-netperf-25\\localadminuser",   vm-name: "netperf-windows-2022-server" },
+          { parent-or-child: "parent=rr1-netperf-05\\localadminuser",   vm-name: "netperf" },
+          { parent-or-child: "parent=rr1-netperf-10\\localadminuser",   vm-name: "netperf" },
         ]
       runs-on:
         - self-hosted

--- a/.github/workflows/reset-parent-or-child.yml
+++ b/.github/workflows/reset-parent-or-child.yml
@@ -12,10 +12,48 @@ on:
         default: "netperf-windows-2022-client"
         required: true
         type: string
+      reset-all-active:
+          description: "Resets all active lab machines"
+          default: false
+          required: false
+          type: boolean
 
 jobs:
+    do-reset-all-active:
+      name: Reset all active lab machines
+      if: ${{ inputs.reset-all-active == true }}
+      strategy:
+        fail-fast: false
+        matrix:
+          vec: [
+            { parent-or-child: "parent=rr1-netperf-26\localadminuser",   vm-name: "netperf-windows-2022-client" },
+            { parent-or-child: "parent=rr1-netperf-25\localadminuser",   vm-name: "netperf-windows-2022-server" },
+            { parent-or-child: "parent=rr1-netperf-05\localadminuser",   vm-name: "netperf" },
+            { parent-or-child: "parent=rr1-netperf-10\localadminuser",   vm-name: "netperf" },
+          ]
+        runs-on:
+          - self-hosted
+          - ${{ matrix.vec.parent-or-child }}
+        steps:
+          - name: RESET STATE (parent or child)
+            run: |
+              # TODO: Eventually, for WS 2025, we want to instead CRUD the VMs, instead of simply reseting their checkpoints here.
+              $vmName = "${{ matrix.vec.vm-name }}"
+              $checkPointName = "LATEST"
+              Restore-VMSnapshot -VMName $vmName -Name $checkPointName -Confirm:$false
+          - name: Start VM, wait for online status, alert observer.
+            run: |
+              $vmName = "${{ matrix.vec.vm-name }}"
+              Start-VM -Name $vmName
+              while (-not (Get-VMNetworkAdapter -VMName $vmName).IPAddresses) {
+                Write-Host "Waiting for VM to be online..."
+                Start-Sleep -Seconds 5
+              }
+              Start-Sleep 10
+
     do-reset-manual:
       name: Reset parent or child Machine
+      if: ${{ inputs.reset-all-active == false }}
       runs-on:
         - self-hosted
         - ${{ inputs.parent-or-child }}

--- a/.github/workflows/reset-parent-or-child.yml
+++ b/.github/workflows/reset-parent-or-child.yml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          { parent-or-child: "parent=rr1-netperf-26\localadminuser",   vm-name: "netperf-windows-2022-client" },
-          { parent-or-child: "parent=rr1-netperf-25\localadminuser",   vm-name: "netperf-windows-2022-server" },
-          { parent-or-child: "parent=rr1-netperf-05\localadminuser",   vm-name: "netperf" },
-          { parent-or-child: "parent=rr1-netperf-10\localadminuser",   vm-name: "netperf" },
+          { parent-or-child: "parent=rr1-netperf-26\\localadminuser",   vm-name: "netperf-windows-2022-client" },
+          { parent-or-child: "parent=rr1-netperf-25\\localadminuser",   vm-name: "netperf-windows-2022-server" },
+          { parent-or-child: "parent=rr1-netperf-05\\localadminuser",   vm-name: "netperf" },
+          { parent-or-child: "parent=rr1-netperf-10\\localadminuser",   vm-name: "netperf" },
         ]
     runs-on:
       - self-hosted

--- a/.github/workflows/reset-parent-or-child.yml
+++ b/.github/workflows/reset-parent-or-child.yml
@@ -27,8 +27,8 @@ jobs:
       matrix:
         vec: [
           { parent-or-child: "parent=rr1-netperf-26\\localadminuser",   vm-name: "netperf-windows-2022-client" },
-          { parent-or-child: "parent=rr1-netperf-25\\localadminuser",   vm-name: "netperf-windows-2022-server" },
-          { parent-or-child: "parent=rr1-netperf-05\\localadminuser",   vm-name: "netperf" },
+          { parent-or-child: "child=rr1-netperf-25\\localadminuser",    vm-name: "netperf-windows-2022-server" },
+          { parent-or-child: "child=rr1-netperf-05\\localadminuser",    vm-name: "netperf" },
           { parent-or-child: "parent=rr1-netperf-10\\localadminuser",   vm-name: "netperf" },
         ]
     runs-on:


### PR DESCRIPTION
Based off an earlier prototype to implement a stateless on-prem lab, we abstracted the process to "reset" a set of lab machines.

To improve upon this abstraction, this pull request adds the option to "bulk" reset all currently active lab machine from a workflow-dispatch.

Testing:

CI
https://github.com/microsoft/netperf/actions/runs/12287205604