### PR TITLE
Add support for MsQuic Logging on Azure Netperf

### DIFF
--- a/.github/actions/run-test-script/action.yml
+++ b/.github/actions/run-test-script/action.yml
@@ -13,10 +13,6 @@ inputs:
     description: "For use to sync with the remote cache."
     type: string
     required: true
-  collect-cpu-traces:
-    description: "Whether to collect CPU traces or not."
-    type: boolean
-    required: false
 runs:
   using: "composite"
   steps:
@@ -39,27 +35,13 @@ runs:
       run_script_powershell_code = """${{ inputs.run-script-cmd }}"""
       squeezed_code = run_script_powershell_code.replace('\n', '').replace('\r', '').replace('`', ' ')
       print(f"::set-output name=squeezed_code::{squeezed_code}")
-
-  - name: Run Pwsh Command With Tracing
-    if: ${{ inputs.collect-cpu-traces && env.HAS_PWSH == 'false' }}
-    run: |
-      powershell -Command "$env:collect_cpu_traces = $true;${{ steps.netperf_context.outputs.netperf_context }} ${{ steps.squeeze_code.outputs.squeezed_code }}"
-    shell: cmd
-  - name: Run Pwsh Command With Tracing
-    if: ${{ inputs.collect-cpu-traces && env.HAS_PWSH == 'true' }}
-    run: |
-      $env:collect_cpu_traces = $true
-      ./netperfrepo/set-netperf-context.ps1 -Matrix '${{ inputs.matrix }}' -SyncerSecret '${{ inputs.syncer-secret }}' -GithubRunId '${{ github.run_id }}-${{ github.run_attempt }}'
-      Import-Module ./netperfrepo/netperf-lib.psm1
-      ${{ inputs.run-script-cmd }}
-    shell: pwsh
   - name: Run Pwsh Command
-    if: ${{ env.HAS_PWSH == 'false' && !inputs.collect-cpu-traces }}
+    if: ${{ env.HAS_PWSH == 'false' }}
     run: |
       powershell -Command "${{ steps.netperf_context.outputs.netperf_context }} ${{ steps.squeeze_code.outputs.squeezed_code }}"
     shell: cmd
   - name: Run Pwsh Command
-    if: ${{ env.HAS_PWSH == 'true' && !inputs.collect-cpu-traces }}
+    if: ${{ env.HAS_PWSH == 'true' }}
     run: |
       ./netperfrepo/set-netperf-context.ps1 -Matrix '${{ inputs.matrix }}' -SyncerSecret '${{ inputs.syncer-secret }}' -GithubRunId '${{ github.run_id }}-${{ github.run_attempt }}'
       Import-Module ./netperfrepo/netperf-lib.psm1

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -387,14 +387,14 @@ jobs:
         name: latency-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
         path: latency.txt
         if-no-files-found: ignore
-
-  attempt-reset-lab:
-    name: Attempting to reset lab. Status of this job does not indicate result of lab reset. Look at job details.
-    needs: [run-secnetperf]
-    if: ${{ always() }}
-    uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
-    with:
-      workflowId: ${{ github.run_id }}
+  # TODO: Revert
+  # attempt-reset-lab:
+  #   name: Attempting to reset lab. Status of this job does not indicate result of lab reset. Look at job details.
+  #   needs: [run-secnetperf]
+  #   if: ${{ always() }}
+  #   uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
+  #   with:
+  #     workflowId: ${{ github.run_id }}
 
   cleanup-cache:
     name: Cleanup Remote Cache Metadata

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -23,11 +23,6 @@ on:
         required: false
         default: false
         type: boolean
-      collect-cpu-traces:
-        description: 'Collect CPU traces'
-        required: false
-        default: false
-        type: boolean
   workflow_dispatch:
     inputs:
       ref:
@@ -61,11 +56,6 @@ on:
           - Full.Verbose
       commit:
         description: 'Publish Results'
-        required: false
-        default: false
-        type: boolean
-      collect-cpu-traces:
-        description: 'Collect CPU traces'
         required: false
         default: false
         type: boolean
@@ -249,7 +239,6 @@ jobs:
           -filter '${{ github.event.client_payload.filter || inputs.filter || '' }}'
         matrix: '${{ toJson(matrix) }}'
         syncer-secret: ${{ secrets.NETPERF_SYNCER_SECRET }}
-        collect-cpu-traces: ${{ github.event.client_payload.collect-cpu-traces || inputs.collect-cpu-traces }}
     - name: Stop 1ES Machine
       if: ${{ always() }}
       uses: ./netperfrepo/.github/actions/stop-1es-machine
@@ -268,20 +257,6 @@ jobs:
       with:
         name: logs-${{ matrix.env }}-${{ matrix.role }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
         path: artifacts/logs
-        if-no-files-found: ignore
-    - name: Upload CPU traces (client)
-      if: ${{ (github.event.client_payload.collect-cpu-traces || inputs.collect-cpu-traces) && matrix.role == 'client' }}
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
-      with:
-        name: client-cpu-traces-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
-        path: "**/cpu-traces*"
-        if-no-files-found: ignore
-    - name: Upload CPU traces (server)
-      if: ${{ (github.event.client_payload.collect-cpu-traces || inputs.collect-cpu-traces) && matrix.role == 'server' }}
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
-      with:
-        name: server-cpu-traces-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
-        path: "**/server-cpu-traces*"
         if-no-files-found: ignore
     - name: Upload Full Latency Curves
       if: ${{ always() }}
@@ -339,10 +314,6 @@ jobs:
       timeout-minutes: 80
       run: |
           $env:netperf_remote_powershell_supported = $true
-          $collectCpuTraces = "${{ github.event.client_payload.collect-cpu-traces || inputs.collect-cpu-traces }}"
-          if ($collectCpuTraces -eq "true") {
-            $env:collect_cpu_traces = $true
-          }
           ./scripts/secnetperf.ps1 `
           -LogProfile ${{ github.event.client_payload.logs || inputs.logprofile || 'NULL' }} `
           -MsQuicCommit ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }} `
@@ -359,20 +330,6 @@ jobs:
       with:
         name: json-test-results-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}.json
         path: json-test-results-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}.json
-    - name: Upload CPU traces (client)
-      if: ${{(github.event.client_payload.collect-cpu-traces || inputs.collect-cpu-traces)}}
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
-      with:
-        name: client-cpu-traces-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
-        path: "**/cpu-traces*"
-        if-no-files-found: ignore
-    - name: Upload CPU traces (server)
-      if: ${{(github.event.client_payload.collect-cpu-traces || inputs.collect-cpu-traces)}}
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
-      with:
-        name: server-cpu-traces-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
-        path: "**/server-cpu-traces*"
-        if-no-files-found: ignore
     - name: Upload Logs
       if: ${{ always() }}
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -266,7 +266,7 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
-        name: logs-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
+        name: logs-${{ matrix.env }}-${{ matrix.role }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
         path: artifacts/logs
         if-no-files-found: ignore
     - name: Upload CPU traces (client)

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -344,14 +344,14 @@ jobs:
         name: latency-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
         path: latency.txt
         if-no-files-found: ignore
-  # TODO: Revert
-  # attempt-reset-lab:
-  #   name: Attempting to reset lab. Status of this job does not indicate result of lab reset. Look at job details.
-  #   needs: [run-secnetperf]
-  #   if: ${{ always() }}
-  #   uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
-  #   with:
-  #     workflowId: ${{ github.run_id }}
+
+  attempt-reset-lab:
+    name: Attempting to reset lab. Status of this job does not indicate result of lab reset. Look at job details.
+    needs: [run-secnetperf]
+    if: ${{ always() }}
+    uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
+    with:
+      workflowId: ${{ github.run_id }}
 
   cleanup-cache:
     name: Cleanup Remote Cache Metadata

--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -5,9 +5,5 @@
     { "env": "azure", "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp", "preferred_pool_sku": "Experimental_Boost4" },
-    { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4" },
-    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp" },
-    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp" },
-    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk" },
-    { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll" }
+    { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4" }
 ]

--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -5,5 +5,9 @@
     { "env": "azure", "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp", "preferred_pool_sku": "Experimental_Boost4" },
-    { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4" }
+    { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4" },
+    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp" },
+    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp" },
+    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk" },
+    { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll" }
 ]


### PR DESCRIPTION
## Description

Expand the "Collect CPU traces" feature that was previously merged where `wpr.exe` was directly invoked to utilize the more established logging power-shell scripts in MsQuic.

Closes: https://github.com/microsoft/netperf/issues/532

## Testing

From this CI run on Netperf:
https://github.com/microsoft/netperf/actions/runs/13820352608/job/38666893105
WPR etl Logs were accumulated with "Basic.Lignt" configuration.

## Documentation

N/A