### PR TITLE
add step to attempt reset lab after running ebpf job

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -106,7 +106,6 @@ jobs:
     - ${{ matrix.vec.env }}
     - os-windows-${{ matrix.vec.os }}
     - ${{ matrix.vec.arch }}
-    - ebpf
 
     steps:
     - name: Setup workspace

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -40,9 +40,7 @@ concurrency:
   group: ebpf-${{ github.event.client_payload.pr || github.event.client_payload.sha || inputs.ref || github.event.pull_request.number || 'main' }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  security-events: write # Required by codeql task
+permissions: write-all
 
 jobs:
   # For automated identification of the workflow.

--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -101,8 +101,6 @@ jobs:
       fail-fast: false
       matrix:
         vec: [
-          #{ env: "azure", os: "2022", arch: "x64" }, # Azure VMs are being deprecated by netperf team.
-          #{ env: "azure", os: "2025", arch: "x64" }, # F4 based VMS are being deprecated by netperf team.
           { env: "lab",   os: "2022", arch: "x64" },
         ]
     runs-on:
@@ -418,6 +416,14 @@ jobs:
         Remove-MpPreference -ExclusionPath ${{ github.workspace }}
         Update-MpSignature -Verbose
         Start-MpScan -ScanType QuickScan
+
+  attempt-reset-lab:
+    name: Attempting to reset lab. Status of this job does not indicate result of lab reset. Look at job details.
+    needs: [test]
+    if: ${{ always() }}
+    uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
+    with:
+      workflowId: ${{ github.run_id }}
 
   # File a bug if the test fails.
   create_or_update_issue:


### PR DESCRIPTION
To fully onboard ebpf-for-windows + netperf, we should add the same job we run after we run msquic perf jobs --- automated lab resets via checkpoints.