### PR TITLE
update github hosted runners to leverage self hosted runners for build-reuse-unix

### DIFF
--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -81,7 +81,7 @@ jobs:
   name:
     name: For ${{ github.event.client_payload.guid }}
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Print Parameters
       if: ${{ github.event_name == 'repository_dispatch' }}
@@ -154,7 +154,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: 'ubuntu-20.04'
+          - os: 'ubuntu-22.04'
             tls: 'openssl'
           - os: 'ubuntu-22.04'
             tls: 'openssl3'
@@ -373,7 +373,7 @@ jobs:
   generate-summary:
     name: Results
     needs: [run-secnetperf, run-secnetperf-1es] # TODO: Add 'observe-lab' once we fully transition to a stateless lab.
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     continue-on-error: true
     steps:
     - name: Checkout repository
@@ -393,7 +393,7 @@ jobs:
     needs: [run-secnetperf, run-secnetperf-1es] # TODO: Add 'observe-lab' once we fully transition to a stateless lab.
     strategy:
       fail-fast: false
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -432,7 +432,7 @@ jobs:
     needs: [save-test-results]
     strategy:
       fail-fast: false
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -464,7 +464,7 @@ jobs:
     continue-on-error: true
     strategy:
       fail-fast: false
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -154,11 +154,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: 'ubuntu-22.04'
+          - os: 'ubuntu-20.04'
             tls: 'openssl'
-          - os: 'ubuntu-22.04'
+          - os: 'ubuntu-20.04'
             tls: 'openssl3'
-    uses: microsoft/msquic/.github/workflows/build-reuse-unix.yml@main
+    uses: microsoft/msquic/.github/workflows/build-reuse-unix.yml@jackhe/fix-for-ubuntu-20.04
     with:
       os: ${{ matrix.os }}
       tls: ${{ matrix.tls }}
@@ -200,7 +200,7 @@ jobs:
     - name: Download Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       with:
-        name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os == 'ubuntu-20.04' && 'ubuntu-22.04' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
+        name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
         path: artifacts
     - name: Download Kernel Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
@@ -301,7 +301,7 @@ jobs:
     - name: Download Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       with:
-        name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os == 'ubuntu-20.04' && 'ubuntu-22.04' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
+        name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
         path: artifacts
     - name: Download Regression.json file
       run: Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/netperf/sqlite/regression.json" -OutFile "regression.json"

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -345,13 +345,13 @@ jobs:
         path: latency.txt
         if-no-files-found: ignore
 
-  # attempt-reset-lab:
-  #   name: Attempting to reset lab. Status of this job does not indicate result of lab reset. Look at job details.
-  #   needs: [run-secnetperf]
-  #   if: ${{ always() }}
-  #   uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
-  #   with:
-  #     workflowId: ${{ github.run_id }}
+  attempt-reset-lab:
+    name: Attempting to reset lab. Status of this job does not indicate result of lab reset. Look at job details.
+    needs: [run-secnetperf]
+    if: ${{ always() }}
+    uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
+    with:
+      workflowId: ${{ github.run_id }}
 
   cleanup-cache:
     name: Cleanup Remote Cache Metadata

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -345,13 +345,13 @@ jobs:
         path: latency.txt
         if-no-files-found: ignore
 
-  attempt-reset-lab:
-    name: Attempting to reset lab. Status of this job does not indicate result of lab reset. Look at job details.
-    needs: [run-secnetperf]
-    if: ${{ always() }}
-    uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
-    with:
-      workflowId: ${{ github.run_id }}
+  # attempt-reset-lab:
+  #   name: Attempting to reset lab. Status of this job does not indicate result of lab reset. Look at job details.
+  #   needs: [run-secnetperf]
+  #   if: ${{ always() }}
+  #   uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
+  #   with:
+  #     workflowId: ${{ github.run_id }}
 
   cleanup-cache:
     name: Cleanup Remote Cache Metadata

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -158,7 +158,7 @@ jobs:
             tls: 'openssl'
           - os: 'ubuntu-20.04'
             tls: 'openssl3'
-    uses: microsoft/msquic/.github/workflows/build-reuse-unix.yml@jackhe/fix-for-ubuntu-20.04
+    uses: microsoft/msquic/.github/workflows/build-reuse-unix.yml@main
     with:
       os: ${{ matrix.os }}
       tls: ${{ matrix.tls }}

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -200,7 +200,7 @@ jobs:
     - name: Download Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       with:
-        name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
+        name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os == 'ubuntu-20.04' && 'ubuntu-22.04' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
         path: artifacts
     - name: Download Kernel Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
@@ -301,7 +301,7 @@ jobs:
     - name: Download Artifacts
       uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d
       with:
-        name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
+        name: Release-${{env.OS}}-${{ matrix.os == 'windows-2025' && 'windows-2022' || matrix.os == 'ubuntu-20.04' && 'ubuntu-22.04' || matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-Perf
         path: artifacts
     - name: Download Regression.json file
       run: Invoke-WebRequest -Uri "https://raw.githubusercontent.com/microsoft/netperf/sqlite/regression.json" -OutFile "regression.json"


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/11101, 
the Github hosted Ubuntu 20.04 runners will undergo deprecation.
Let's update to 22.04 for quic workflows.