### PR TITLE
Switch from OpenSSL to QuicTLS

### DIFF
--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -127,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-2022']
-        tls: [schannel] # , openssl, openssl3]
+        tls: [schannel] # , quictls]
     uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
     with:
       os: ${{ matrix.os }}
@@ -155,9 +155,7 @@ jobs:
       matrix:
         include:
           - os: 'ubuntu-20.04'
-            tls: 'openssl'
-          - os: 'ubuntu-22.04'
-            tls: 'openssl3'
+            tls: 'quictls'
     uses: microsoft/msquic/.github/workflows/build-reuse-unix.yml@main
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -2,12 +2,12 @@
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4" },
-    { "env": "azure", "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll", "preferred_pool_sku": "Experimental_Boost4" },
+    { "env": "azure", "os": "ubuntu-20.04", "arch": "x64", "tls": "quictls",  "io": "epoll", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk" },
-    { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "openssl",  "io": "epoll" }
+    { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "quictls",  "io": "epoll" }
 ]


### PR DESCRIPTION
MsQuic recently renamed these in preparation for a separate support of true OpenSSL.