### PR TITLE
Update deprecated ubuntu GH runner to 22.04

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -50,7 +50,7 @@ jobs:
     name: For ${{ github.event.client_payload.guid }}
     if: ${{ github.event_name == 'repository_dispatch' }}
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - run: |
         echo "guid: ${{ github.event.client_payload.guid }}"


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/11101,

let's remove references to ubuntu 20.04 github runners.