### PR TITLE
Expand lab bench

### DIFF
--- a/.github/workflows/auto-reset-parent-or-child-lab-machine.yml
+++ b/.github/workflows/auto-reset-parent-or-child-lab-machine.yml
@@ -89,6 +89,14 @@ jobs:
           { parent-or-child: "parent=rr1-netperf-43\\localadminuser",   vm-name: "netperf-windows-2022-client" },
           { parent-or-child: "child=rr1-netperf-11\\localadminuser",    vm-name: "netperf-linux-server" },
           { parent-or-child: "parent=rr1-netperf-12\\localadminuser",   vm-name: "netperf-linux-client" },
+          { parent-or-child: "child=rr1-netperf-01\\localadminuser",     vm-name: "netperf-windows-2022-server" },
+          { parent-or-child: "parent=rr1-netperf-02\\localadminuser",    vm-name: "netperf-windows-2022-client" },
+          { parent-or-child: "child=rr1-netperf-03\\localadminuser",     vm-name: "netperf-windows-2022-server" },
+          { parent-or-child: "parent=rr1-netperf-04\\localadminuser",    vm-name: "netperf-windows-2022-client" },
+          { parent-or-child: "child=rr1-netperf-06\\localadminuser",     vm-name: "netperf-windows-2022-server" },
+          { parent-or-child: "parent=rr1-netperf-07\\localadminuser",    vm-name: "netperf-windows-2022-client" },
+          { parent-or-child: "child=rr1-netperf-08\\localadminuser",     vm-name: "netperf-windows-2022-server" },
+          { parent-or-child: "parent=rr1-netperf-09\\localadminuser",    vm-name: "netperf-windows-2022-client" }
         ]
     runs-on:
       - self-hosted


### PR DESCRIPTION
After validating that the resets work: https://github.com/microsoft/netperf/actions/runs/14782573039
and that the newly added runners are able to accept and run jobs, let's add them to the netperf bench.
After this PR gets merged, I will mark the necessary runners as available for use for future jobs.