### PR TITLE
Replace end-of-life Ubuntu 20.04 LTS with 24.04 LTS

### DIFF
--- a/.github/workflows/create-azure-machine.ps1
+++ b/.github/workflows/create-azure-machine.ps1
@@ -11,7 +11,7 @@ param (
     [string]$Password,
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("windows-2025", "windows-2022", "windows-2019", "ubuntu-22.04", "ubuntu-20.04", "ubuntu-18.04", "mariner-2")]
+    [ValidateSet("windows-2025", "windows-2022", "windows-2019", "ubuntu-22.04", "ubuntu-24.04", "ubuntu-18.04", "mariner-2")]
     [string]$Os = "windows-2022",
 
     [Parameter(Mandatory = $false)]
@@ -50,10 +50,8 @@ if ($Os -eq "windows-2025") {
     $image = "MicrosoftWindowsServer:WindowsServer:2019-datacenter-gensecond:17763.5576.240304"
 } elseif ($Os -eq "ubuntu-22.04") {
     $image = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202403010"
-} elseif ($Os -eq "ubuntu-20.04") {
-    $image = "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202402290"
-} elseif ($Os -eq "ubuntu-18.04") {
-    $image = "Canonical:UbuntuServer:18_04-lts-gen2:18.04.202402250"
+} elseif ($Os -eq "ubuntu-24.04") {
+    $image = " Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
 } elseif ($Os -eq "mariner-2") {
     $image = "MicrosoftCBLMariner:cbl-mariner:cbl-mariner-2-gen2:2.20240223.01" # This image may not exist
 } else {

--- a/.github/workflows/create-azure-machine.ps1
+++ b/.github/workflows/create-azure-machine.ps1
@@ -51,7 +51,7 @@ if ($Os -eq "windows-2025") {
 } elseif ($Os -eq "ubuntu-22.04") {
     $image = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202403010"
 } elseif ($Os -eq "ubuntu-24.04") {
-    $image = " Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+    $image = " Canonical:ubuntu-24_04-lts:server:latest"
 } elseif ($Os -eq "mariner-2") {
     $image = "MicrosoftCBLMariner:cbl-mariner:cbl-mariner-2-gen2:2.20240223.01" # This image may not exist
 } else {

--- a/.github/workflows/ebpf_dynamic_vm.yml
+++ b/.github/workflows/ebpf_dynamic_vm.yml
@@ -40,7 +40,7 @@ concurrency:
 
 # Need to determine why this is required.
 permissions: write-all
- 
+
 
 jobs:
   # For automated identification of the workflow.
@@ -48,7 +48,7 @@ jobs:
     name: For ${{ github.event.client_payload.guid }}
     if: ${{ github.event_name == 'repository_dispatch' }}
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - run: |
         echo "guid: ${{ github.event.client_payload.guid }}"
@@ -239,7 +239,7 @@ jobs:
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: cts_traffic_baseline_${{ matrix.env }}_${{ matrix.os }}_${{ matrix.arch }}
-        path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv 
+        path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv
 
     - name: Attach xdp baseline program to interface (first program in xdp.sys)
       working-directory: ${{ github.workspace }}\bpf_performance
@@ -293,7 +293,7 @@ jobs:
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: cts_traffic_xdp_${{ matrix.env }}_${{ matrix.os }}_${{ matrix.arch }}
-        path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv 
+        path: ${{ github.workspace }}\cts-traffic\ctsTrafficResults.csv
 
     - name: Run BPF performance tests
       working-directory: ${{ github.workspace }}\bpf_performance
@@ -351,11 +351,10 @@ jobs:
         if (Test-Path ${{ github.workspace }}\xdp) { Remove-Item -Recurse -Force ${{ github.workspace }}\xdp }
         if (Test-Path ${{ github.workspace }}\cts-traffic) { Remove-Item -Recurse -Force ${{ github.workspace }}\cts-traffic }
         if (Test-Path ${{ github.workspace }}\ETL) { Remove-Item -Recurse -Force ${{ github.workspace }}\ETL }
-        
+
     - name: Restore Windows Defender exclusions
       if: always()
       run: |
         Remove-MpPreference -ExclusionPath ${{ github.workspace }}
         Update-MpSignature -Verbose
         Start-MpScan -ScanType QuickScan
-

--- a/.github/workflows/ebpf_linux.yml
+++ b/.github/workflows/ebpf_linux.yml
@@ -33,9 +33,9 @@ permissions:
 
 jobs:
   build:
-    runs-on: 
+    runs-on:
     - self-hosted
-    - os-ubuntu-20.04
+    - os-ubuntu-24.04
     - x64
 
     steps:
@@ -54,7 +54,7 @@ jobs:
           lcov \
           pkg-config \
           libelf-dev
-    
+
     - name: Clone and build libbpf
       run: |
         git clone https://github.com/libbpf/libbpf.git
@@ -74,7 +74,7 @@ jobs:
         cmake \
           -B ${{github.workspace}}/build \
           -DCMAKE_BUILD_TYPE=Release
-    
+
     - name: Build
       run: |
         cmake --build ${{github.workspace}}/build --config Release -- -j $(nproc)

--- a/.github/workflows/ebpf_linux.yml
+++ b/.github/workflows/ebpf_linux.yml
@@ -34,9 +34,7 @@ permissions:
 jobs:
   build:
     runs-on:
-    - self-hosted
-    - os-ubuntu-24.04
-    - x64
+    - ubuntu-24.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/manage-azure-vms.ps1
+++ b/.github/workflows/manage-azure-vms.ps1
@@ -170,7 +170,7 @@ foreach ($entry in $MatrixJson) {
         $entry | Add-Member -MemberType NoteProperty -Name "runner_id" -Value $randomTag
         $AzureJson += $entry
         $ProcessedJson += $entry
-    } elseif ($entry.env -match "azure" -and $entry.os -match "ubuntu-20.04") {
+    } elseif ($entry.env -match "azure" -and $entry.os -match "ubuntu-24.04") {
         continue
     } else {
         $ProcessedJson += $entry

--- a/.github/workflows/prepare-matrix.ps1
+++ b/.github/workflows/prepare-matrix.ps1
@@ -19,7 +19,7 @@ $FullJson = @()
 foreach ($entry in $MatrixJson) {
     if ($entry.env -match "azure") {
         $Windows2022Pool = "netperf-actual-boosted-winprerelease" # TODO: "boost-prerelease" name is misleading. Change it to be "boosted-windows-2022".
-        $UbuntuPool =  "netperf-boosted-linux-pool"               # NOTE: This pool is using experimental boost SKUs. boosted-netperf-ubuntu-20.04-gen2.
+        $UbuntuPool =  "netperf-boosted-linux-pool"               # NOTE: This pool is using experimental boost SKUs. boosted-netperf-ubuntu-24.04-gen2.
         $Windows2025Pool = "netperf-boosted-windows-pool"         # NOTE: This runs the latest ge_current_directiof_stack build.
         $client = $entry.PSObject.Copy()
         $server = $entry.PSObject.Copy()
@@ -28,7 +28,7 @@ foreach ($entry in $MatrixJson) {
         if ($hasPreferredPoolSku) {
             if ($entry.preferred_pool_sku -eq "Standard_F8s_v2") {
                 $Windows2022Pool = "netperf-f-series-windows-2022"
-                $Ubuntu2004Pool =  "netperf-f-series-ubuntu-20.04"
+                $Ubuntu2404Pool =  "netperf-f-series-ubuntu-24.04"
             }
         }
 
@@ -43,13 +43,6 @@ foreach ($entry in $MatrixJson) {
             $server | Add-Member -MemberType NoteProperty -Name "remote_powershell_supported" -Value 'FALSE'
             $client.assigned_os = "managed-windows-2022-gen2-try3"
             $server.assigned_os = "managed-windows-2022-gen2-try3"
-        } elseif ($entry.os -match "ubuntu-20.04") {
-            $client | Add-Member -MemberType NoteProperty -Name "assigned_pool" -Value $UbuntuPool
-            $server | Add-Member -MemberType NoteProperty -Name "assigned_pool" -Value $UbuntuPool
-            $client | Add-Member -MemberType NoteProperty -Name "remote_powershell_supported" -Value 'FALSE'
-            $server | Add-Member -MemberType NoteProperty -Name "remote_powershell_supported" -Value 'FALSE'
-            $client.assigned_os = "boosted-netperf-ubuntu-20.04-gen2"
-            $server.assigned_os = "boosted-netperf-ubuntu-20.04-gen2"
         } elseif ($entry.os -match "ubuntu-24.04") {
             $client | Add-Member -MemberType NoteProperty -Name "assigned_pool" -Value $UbuntuPool
             $server | Add-Member -MemberType NoteProperty -Name "assigned_pool" -Value $UbuntuPool
@@ -65,7 +58,7 @@ foreach ($entry in $MatrixJson) {
             $client.assigned_os = "nvme-enabled-ge_current_directiof_stack-try2"
             $server.assigned_os = "nvme-enabled-ge_current_directiof_stack-try2"
         } else {
-            throw "Invalid OS entry (Must be either windows-2022 or ubuntu-20.04). Got: $($entry.os)"
+            throw "Invalid OS entry (Must be either windows-2022 or ubuntu-24.04). Got: $($entry.os)"
         }
         $client | Add-Member -MemberType NoteProperty -Name "role" -Value "client"
         $server | Add-Member -MemberType NoteProperty -Name "role" -Value "server"

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-24.04']
+        os: ['ubuntu-24.04']
         tls: ['quictls']
     uses: microsoft/msquic/.github/workflows/build-reuse-unix.yml@main
     with:

--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -8,6 +8,5 @@
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp" },
-    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk" },
-    { "env": "lab",   "os": "ubuntu-24.04", "arch": "x64", "tls": "quictls",  "io": "epoll" }
+    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk" }
 ]

--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -2,7 +2,6 @@
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4" },
-    { "env": "azure", "os": "ubuntu-20.04", "arch": "x64", "tls": "quictls",  "io": "epoll", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "ubuntu-24.04", "arch": "x64", "tls": "quictls",  "io": "epoll", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp", "preferred_pool_sku": "Experimental_Boost4" },
@@ -10,5 +9,5 @@
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk" },
-    { "env": "lab",   "os": "ubuntu-20.04", "arch": "x64", "tls": "quictls",  "io": "epoll" }
+    { "env": "lab",   "os": "ubuntu-24.04", "arch": "x64", "tls": "quictls",  "io": "epoll" }
 ]

--- a/.github/workflows/update-react.yml
+++ b/.github/workflows/update-react.yml
@@ -23,7 +23,7 @@ jobs:
     needs: []
     strategy:
       fail-fast: false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -48,7 +48,7 @@ jobs:
     needs: [npm-build]
     strategy:
       fail-fast: false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/xdp.yml
+++ b/.github/workflows/xdp.yml
@@ -29,7 +29,7 @@ jobs:
     name: For ${{ github.event.client_payload.guid }}
     if: ${{ github.event_name == 'repository_dispatch' }}
     needs: []
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - run: |
         echo "guid: ${{ github.event.client_payload.guid }}"

--- a/dashboard/src/pages/hps.jsx
+++ b/dashboard/src/pages/hps.jsx
@@ -60,7 +60,7 @@ export default function HpsPage() {
 
   const [windowsOs, setWindowsOs] = useState('windows-2022-x64')
 
-  const [linuxOs, setLinuxOs] = useState('ubuntu-20.04-x64')
+  const [linuxOs, setLinuxOs] = useState('ubuntu-24.04-x64')
 
   const [testType, setTestType] = useState('hps-conns-100')
 
@@ -227,7 +227,7 @@ export default function HpsPage() {
               onChange={handleChangeLinuxOs}
               defaultValue={0}
             >
-              <MenuItem value='ubuntu-20.04-x64'>ubuntu-20.04-x64</MenuItem>
+              <MenuItem value='ubuntu-24.04-x64'>ubuntu-24.04-x64</MenuItem>
             </Select>
           </FormControl>
         </Box>

--- a/dashboard/src/pages/latency.jsx
+++ b/dashboard/src/pages/latency.jsx
@@ -60,7 +60,7 @@ export default function LatencyPage() {
 
   const [windowsOs, setWindowsOs] = useState('windows-2022-x64')
 
-  const [linuxOs, setLinuxOs] = useState('ubuntu-20.04-x64')
+  const [linuxOs, setLinuxOs] = useState('ubuntu-24.04-x64')
 
   const [testType, setTestType] = useState('rps-up-512-down-4000')
 
@@ -255,7 +255,7 @@ export default function LatencyPage() {
                 onChange={handleChangeLinuxOs}
                 defaultValue={0}
               >
-                <MenuItem value='ubuntu-20.04-x64'>ubuntu-20.04-x64</MenuItem>
+                <MenuItem value='ubuntu-24.04-x64'>ubuntu-24.04-x64</MenuItem>
               </Select>
             </FormControl>
           </Box>
@@ -325,4 +325,3 @@ export default function LatencyPage() {
     </>
   );
 }
-

--- a/dashboard/src/pages/rps.jsx
+++ b/dashboard/src/pages/rps.jsx
@@ -60,7 +60,7 @@ export default function RpsPage() {
 
   const [windowsOs, setWindowsOs] = useState('windows-2022-x64')
 
-  const [linuxOs, setLinuxOs] = useState('ubuntu-20.04-x64')
+  const [linuxOs, setLinuxOs] = useState('ubuntu-24.04-x64')
 
   const [testType, setTestType] = useState('rps-up-512-down-4000')
 
@@ -227,7 +227,7 @@ export default function RpsPage() {
               onChange={handleChangeLinuxOs}
               defaultValue={0}
             >
-              <MenuItem value='ubuntu-20.04-x64'>ubuntu-20.04-x64</MenuItem>
+              <MenuItem value='ubuntu-24.04-x64'>ubuntu-24.04-x64</MenuItem>
             </Select>
           </FormControl>
         </Box>

--- a/dashboard/src/pages/throughput.jsx
+++ b/dashboard/src/pages/throughput.jsx
@@ -61,7 +61,7 @@ export default function ThroughputPage() {
 
   const [windowsOs, setWindowsOs] = useState('windows-2022-x64')
 
-  const [linuxOs, setLinuxOs] = useState('ubuntu-20.04-x64')
+  const [linuxOs, setLinuxOs] = useState('ubuntu-24.04-x64')
 
   const [testType, setTestType] = useState('up')
 
@@ -225,7 +225,7 @@ export default function ThroughputPage() {
               onChange={handleChangeLinuxOs}
               defaultValue={0}
             >
-              <MenuItem value='ubuntu-20.04-x64'>ubuntu-20.04-x64</MenuItem>
+              <MenuItem value='ubuntu-24.04-x64'>ubuntu-24.04-x64</MenuItem>
             </Select>
           </FormControl>
         </Box>

--- a/dashboard/src/sections/overview/view/app-view.jsx
+++ b/dashboard/src/sections/overview/view/app-view.jsx
@@ -44,7 +44,7 @@ export default function AppView() {
 
   const [windowsOs, setWindowsOs] = useState('windows-2022-x64')
 
-  const [linuxOs, setLinuxOs] = useState('ubuntu-20.04-x64')
+  const [linuxOs, setLinuxOs] = useState('ubuntu-24.04-x64')
 
   const windows = useFetchData(
     `https://raw.githubusercontent.com/microsoft/netperf/deploy/json-test-results-${env}-${windowsOs}-schannel-iocp.json/json-test-results-${env}-${windowsOs}-schannel-iocp.json`
@@ -115,7 +115,7 @@ export default function AppView() {
   let windowsKernelLatencyQuic = [-1, -1, -1, -1, -1, -1, -1, -1];
   let commitHash = "";
   let windowsType = 'Windows Server 2022';
-  let linuxType = 'Linux Ubuntu 20.04 LTS';
+  let linuxType = 'Linux Ubuntu 24.04 LTS';
 
   function index(object, keys, defaultValue) {
     for (const key of keys) {
@@ -292,7 +292,7 @@ export default function AppView() {
               onChange={handleChangeLinuxOs}
               defaultValue={0}
             >
-              <MenuItem value='ubuntu-20.04-x64'>ubuntu-20.04-x64</MenuItem>
+              <MenuItem value='ubuntu-24.04-x64'>ubuntu-24.04-x64</MenuItem>
             </Select>
           </FormControl>
         </Box>

--- a/docs/archive/next-steps.md
+++ b/docs/archive/next-steps.md
@@ -12,7 +12,7 @@
 
 ### What needs to be done:
 
-- Stand up the 1ES Azure testing for Windows 2022, Windows Prerelease, Ubuntu 20.04, Ubuntu 22.04 using whatever means to get things functional (~2 weeks)
+- Stand up the 1ES Azure testing for Windows 2022, Windows Prerelease, Ubuntu 24.04, Ubuntu 22.04 using whatever means to get things functional (~2 weeks)
 - Stabilize the static lab machine/VMs to eliminate all the environment errors we're seeing (xdp still running!) (~2 weeks)
 
 # Netperf Release V2

--- a/docs/archive/tech-specs.md
+++ b/docs/archive/tech-specs.md
@@ -39,7 +39,7 @@ That is how we do Azure testing today with "temporary" VMs.
 
 In our lab, we set the requirement of 1 VM per host. That means for our tests, we need at least 2 physical hosts.
 
-We manually onboarded Windows 2022 VMs on 2 of our lab machines that we hand-picked. We added the "client" Windows 2022 VM as a self-hosted Github runner with some tags we assigned ourselves. We did the same with Ubuntu 20.04.
+We manually onboarded Windows 2022 VMs on 2 of our lab machines that we hand-picked. We added the "client" Windows 2022 VM as a self-hosted Github runner with some tags we assigned ourselves. We did the same with Ubuntu 24.04.
 
 Whenever we need to run lab tests, our Github Actions workflow runs will reference the static VMs we added.
 
@@ -70,4 +70,3 @@ Either 1ES hosted pool or CloudTest can worry about  giving us the resources per
 We don't need to worry about infrastructure.
 
 Either 1ES hosted pool or CloudTest can worry about  giving us the resources per job (2 **test-ready** VMs) and we can just reference them in our Github Actions workflow.
-

--- a/docs/lab_consumption.md
+++ b/docs/lab_consumption.md
@@ -4,8 +4,8 @@ Write your performance test workflow like:
 ```yaml
 jobs:
     Your_Perf_Job:
-        # Currently only windows-2022/ubuntu-20.04 lab runners are available.
-        runs-on: [self-hosted, lab, <windows-2022 / ubuntu-20.04>]
+        # Currently only windows-2022/ubuntu-24.04 lab runners are available.
+        runs-on: [self-hosted, lab, <windows-2022 / ubuntu-24.04>]
         steps:
             - ... # Checkout your project repo...
             - ... # Download your perf tools...

--- a/setup-runner-linux.sh
+++ b/setup-runner-linux.sh
@@ -78,7 +78,7 @@ fi
 # Installing powershell 7 (NOTE: Sometimes, will have to run this again because powershell fails to install the first run. Need investigation.)
 echo "================= Installing powershell 7. ================="
 sudo apt-get install -y wget apt-transport-https software-properties-common
-wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
+wget -q https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 echo "================= Updating apt-get again. ================="
 sudo apt-get update


### PR DESCRIPTION
Replace 20.04, which is end-of-life, with 24.04, the most recent long-term support release.

This breaks the lab, which doesn't have 24.04 images yet, so remove those from the rotation for now. We need to get green on using supported OSes.

#608 tracks adding the lab image