### PR TITLE
Install MANA drivers on windows runners

### DIFF
--- a/.github/actions/prepare-1es-machine/action.yml
+++ b/.github/actions/prepare-1es-machine/action.yml
@@ -58,5 +58,5 @@ runs:
     shell: PowerShell
   - name: Invoke setup-runner-linux.sh
     if: ${{ runner.os != 'Windows' }}
-    run: ./netperfrepo/setup-runner-linux.sh
+    run: sudo bash ./netperfrepo/setup-runner-linux.sh
     shell: bash

--- a/.github/actions/prepare-1es-machine/action.yml
+++ b/.github/actions/prepare-1es-machine/action.yml
@@ -54,9 +54,9 @@ runs:
       python-version: '3.x'
   - name: Invoke setup-runner-windows.ps1
     if: ${{ runner.os == 'Windows' }}
-    run: .\netperfrepo\setup-runner-windows.ps1
+    run: ./netperfrepo/setup-runner-windows.ps1
     shell: PowerShell
   - name: Invoke setup-runner-linux.sh
     if: ${{ runner.os != 'Windows' }}
-    run: .\netperfrepo\setup-runner-linux.sh
+    run: ./netperfrepo/setup-runner-linux.sh
     shell: bash

--- a/.github/actions/prepare-1es-machine/action.yml
+++ b/.github/actions/prepare-1es-machine/action.yml
@@ -52,3 +52,11 @@ runs:
     uses: actions/setup-python@v2
     with:
       python-version: '3.x'
+  - name: Invoke setup-runner-windows.ps1
+    if: ${{ runner.os == 'Windows' }}
+    run: .\netperfrepo\setup-runner-windows.ps1
+    shell: PowerShell
+  - name: Invoke setup-runner-linux.sh
+    if: ${{ runner.os != 'Windows' }}
+    run: .\netperfrepo\setup-runner-linux.sh
+    shell: bash

--- a/.github/actions/prepare-1es-machine/action.yml
+++ b/.github/actions/prepare-1es-machine/action.yml
@@ -56,7 +56,3 @@ runs:
     if: ${{ runner.os == 'Windows' }}
     run: ./netperfrepo/setup-runner-windows.ps1
     shell: PowerShell
-  - name: Invoke setup-runner-linux.sh
-    if: ${{ runner.os != 'Windows' }}
-    run: sudo bash ./netperfrepo/setup-runner-linux.sh
-    shell: bash


### PR DESCRIPTION
MANA drivers are missing on our Windows Server 2025 images, and we might not have the latest versions on other images.

Install the drivers as part of the setup-runner script. This script unfortunately only runs regularly on Azure VMs, not on lab machines, but since we do not have MANA in our lab right now, this is not a huge problem.