### PR TITLE
Add independent server IO knobs for QUIC

### DIFF
--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -234,7 +234,7 @@ jobs:
           -arch ${{ matrix.arch }} `
           -tls ${{ matrix.tls }} `
           -io ${{ matrix.io }} `
-          -serverio ${{ matrix.serverio }} `
+          -serverio '${{ matrix.serverio }}' `
           -filter '${{ github.event.client_payload.filter || inputs.filter || '' }}'
         matrix: '${{ toJson(matrix) }}'
         syncer-secret: ${{ secrets.NETPERF_SYNCER_SECRET }}
@@ -323,7 +323,7 @@ jobs:
           -arch ${{ matrix.arch }} `
           -tls ${{ matrix.tls }} `
           -io ${{ matrix.io }} `
-          -serverio ${{ matrix.serverio }} `
+          -serverio '${{ matrix.serverio }}' `
           -filter '${{ github.event.client_payload.filter || inputs.filter || '' }}'
     - name: Upload Test Results JSON
       if: ${{ always() }}

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -322,25 +322,26 @@ jobs:
           -arch ${{ matrix.arch }} `
           -tls ${{ matrix.tls }} `
           -io ${{ matrix.io }} `
+          -serverio ${{ matrix.serverio }} `
           -filter '${{ github.event.client_payload.filter || inputs.filter || '' }}'
     - name: Upload Test Results JSON
       if: ${{ always() }}
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
-        name: json-test-results-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}.json
-        path: json-test-results-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}.json
+        name: json-test-results-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}-${{ matrix.serverio }}.json
+        path: json-test-results-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}-${{ matrix.serverio }}.json
     - name: Upload Logs
       if: ${{ always() }}
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
-        name: logs-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
+        name: logs-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}-${{ matrix.serverio }}
         path: artifacts/logs
         if-no-files-found: ignore
     - name: Upload Full Latency Curves
       if: ${{ always() }}
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
-        name: latency-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
+        name: latency-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}-${{ matrix.serverio }}
         path: latency.txt
         if-no-files-found: ignore
 

--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -171,7 +171,7 @@ jobs:
       workflowId: ${{ github.run_id }}-${{ github.run_attempt }}
 
   run-secnetperf-1es:
-    name: ${{ matrix.optional == 'TRUE' && '[UNRELIABLE]-' || '' }}azure-${{ matrix.os }}-${{ matrix.io }}-${{ matrix.role }}-${{ matrix.tls }}-${{ matrix.arch }}
+    name: ${{ matrix.optional == 'TRUE' && '[UNRELIABLE]-' || '' }}azure-${{ matrix.os }}-${{ matrix.io }}-${{ matrix.serverio }}-${{ matrix.role }}-${{ matrix.tls }}-${{ matrix.arch }}
     needs: [prepare-matrix, build-windows, build-windows-kernel, build-unix]
     strategy:
       fail-fast: false
@@ -234,6 +234,7 @@ jobs:
           -arch ${{ matrix.arch }} `
           -tls ${{ matrix.tls }} `
           -io ${{ matrix.io }} `
+          -serverio ${{ matrix.serverio }} `
           -filter '${{ github.event.client_payload.filter || inputs.filter || '' }}'
         matrix: '${{ toJson(matrix) }}'
         syncer-secret: ${{ secrets.NETPERF_SYNCER_SECRET }}
@@ -247,20 +248,20 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
-        name: json-test-results-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}.json
-        path: json-test-results-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}.json
+        name: json-test-results-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}-${{ matrix.serverio }}.json
+        path: json-test-results-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}-${{ matrix.serverio }}.json
     - name: Upload Logs
       if: ${{ always() }}
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
-        name: logs-${{ matrix.env }}-${{ matrix.role }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
+        name: logs-${{ matrix.env }}-${{ matrix.role }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}-${{ matrix.serverio }}
         path: artifacts/logs
         if-no-files-found: ignore
     - name: Upload Full Latency Curves
       if: ${{ always() }}
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
-        name: latency-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}
+        name: latency-${{ matrix.env }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.tls }}-${{ matrix.io }}-${{ matrix.serverio }}
         path: latency.txt
         if-no-files-found: ignore
 
@@ -269,7 +270,7 @@ jobs:
   # NOTE: tag == env
   #
   run-secnetperf:
-    name:  ${{ matrix.optional == 'TRUE' && '[UNRELIABLE]-' || '' }}lab-${{ matrix.os }}-${{ matrix.io }}-${{ matrix.tls }}-${{ matrix.arch }}
+    name:  ${{ matrix.optional == 'TRUE' && '[UNRELIABLE]-' || '' }}lab-${{ matrix.os }}-${{ matrix.io }}-${{ matrix.serverio }}-${{ matrix.tls }}-${{ matrix.arch }}
     needs: [prepare-matrix, build-windows, build-windows-kernel, build-unix]
     strategy:
       fail-fast: false

--- a/.github/workflows/quic_matrix.json
+++ b/.github/workflows/quic_matrix.json
@@ -8,5 +8,14 @@
     { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk", "preferred_pool_sku": "Experimental_Boost4" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp" },
     { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp" },
-    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk" }
+    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk" },
+    { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp", "serverio": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
+    { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp", "serverio": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
+    { "env": "azure", "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk", "serverio": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
+    { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "iocp", "serverio": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
+    { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "xdp", "serverio": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
+    { "env": "azure", "os": "windows-2025", "arch": "x64", "tls": "schannel", "io": "wsk", "serverio": "iocp", "preferred_pool_sku": "Experimental_Boost4" },
+    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "iocp", "serverio": "iocp" },
+    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "xdp", "serverio": "iocp" },
+    { "env": "lab",   "os": "windows-2022", "arch": "x64", "tls": "schannel", "io": "wsk", "serverio": "iocp" }
 ]


### PR DESCRIPTION
To independently test the client IO mode vs a constant server IO mode across IO models, add a new serverio knob. Pick `icop` as the common server mode for a new matrix of tests. Depends on #TODO in MsQuic.