### PR TITLE
Simplify Netperf API

### DIFF
--- a/.github/workflows/quic.yml
+++ b/.github/workflows/quic.yml
@@ -289,6 +289,10 @@ jobs:
       with:
         repository: microsoft/msquic
         ref: ${{ github.event.client_payload.sha || github.event.client_payload.ref || inputs.ref || 'main' }}
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      with:
+        path: netperfrepo
     - name: Lowercase runner.os
       shell: pwsh
       run: echo "OS=$('${{runner.os}}'.ToLower())" >> $env:GITHUB_ENV
@@ -313,6 +317,7 @@ jobs:
       shell: pwsh
       timeout-minutes: 80
       run: |
+          Import-Module ./netperfrepo/netperf-lib.psm1
           $env:netperf_remote_powershell_supported = $true
           ./scripts/secnetperf.ps1 `
           -LogProfile ${{ github.event.client_payload.logs || inputs.logprofile || 'NULL' }} `

--- a/netperf-lib.psm1
+++ b/netperf-lib.psm1
@@ -113,10 +113,14 @@ function NetperfWaitServerFinishExecution {
 function InitNetperfLib {
     param (
         $CallbackName,
-        $RemoteDir
+        $RemoteDir,
+        $RemoteName,
+        $UserNameOnLinux
     )
     $env:CallbackName = $CallbackName
     $env:RemoteDir = $RemoteDir
+    $env:RemoteName = $RemoteName
+    $env:UserNameOnLinux = $UserNameOnLinux
     $RemotePowershellSupported = $env:netperf_remote_powershell_supported
     if ($RemotePowershellSupported -eq $true) {
 
@@ -143,7 +147,7 @@ function InitNetperfLib {
                     $cred = New-Object System.Management.Automation.PSCredential ($username, $password)
                     $Session = New-PSSession -ComputerName $RemoteName -Credential $cred -ConfigurationName PowerShell.7
                 } else {
-                    $Session = New-PSSession -HostName $RemoteName -UserName $UserName -SSHTransport
+                    $Session = New-PSSession -HostName $RemoteName -UserName $UserNameOnLinux -SSHTransport
                 }
                 break
             } catch {

--- a/netperf-lib.psm1
+++ b/netperf-lib.psm1
@@ -23,7 +23,7 @@ function NetperfSendCommand {
         $CallBackName = $env:CallBackName
         $RemoteDir = $env:RemoteDir
         Invoke-Command -Session $Session -ScriptBlock {
-            & "$Using:RemoteDir/scripts/$Using:CallBackName" -Command $Using:Command
+            & "$Using:RemoteDir/scripts/$Using:CallBackName" -Command $Using:Command -WorkingDir $Using:RemoteDir
         }
         return
     }

--- a/netperf-lib.psm1
+++ b/netperf-lib.psm1
@@ -13,9 +13,23 @@ function ValidateInheritedParams {
 function NetperfSendCommand {
     param (
         [Parameter(Mandatory = $true)]
-        [string]$Command
+        [string]$Command,
+        [Parameter(Mandatory = $false)]
+        $Session
     )
-    Write-Host "Sending command: $Command"
+
+    if ($Session -and $Session -ne "NOT_SUPPORTED") {
+        Write-Host "Sending command (via remote powershell): $Command"
+        $CallBackName = $env:CallBackName
+        $RemoteDir = $env:RemoteDir
+        Invoke-Command -Session $Session -ScriptBlock {
+            & "$Using:RemoteDir/scripts/$Using:CallBackName" -Command $Using:Command
+        }
+        return
+    }
+
+
+    Write-Host "Sending command (via remote cache): $Command"
     # Should send a command to the shared cache and wait for the server process to execute said command before exiting.
     $headers = @{
         "secret" = "$env:netperf_syncer_secret"
@@ -57,9 +71,14 @@ function NetperfWaitServerFinishExecution {
         [Parameter(Mandatory = $false)]
         [int]$WaitPerAttempt = 8,
         [Parameter(Mandatory = $false)]
-        [scriptblock]$UnblockRoutine = {}
+        [scriptblock]$UnblockRoutine = {},
+        [Parameter(Mandatory = $false)]
+        $Session
     )
-
+    if ($Session -and $Session -ne "NOT_SUPPORTED") {
+        Write-Host "No need to wait if we are doing remote powershell..."
+        return
+    }
     for ($i = 0; $i -lt $maxattempts; $i++) {
         $UnblockRoutine.Invoke()
         Write-Host "Waiting for server to finish execution... Attempt $i"
@@ -88,4 +107,79 @@ function NetperfWaitServerFinishExecution {
     }
 
     throw "Server did not finish execution in time! Tried $maxattempts times with $WaitPerAttempt seconds interval."
+}
+
+
+function InitNetperfLib {
+    param (
+        $CallbackName,
+        $RemoteDir
+    )
+    $env:CallbackName = $CallbackName
+    $env:RemoteDir = $RemoteDir
+    $RemotePowershellSupported = $env:netperf_remote_powershell_supported
+    if ($RemotePowershellSupported -eq $true) {
+
+        # Set up the connection to the peer over remote powershell.
+        Write-Host "Connecting to $RemoteName"
+        $Attempts = 0
+        while ($Attempts -lt 5) {
+            if ($environment -eq "azure") {
+                if ($isWindows) {
+                    Write-Host "Attempting to connect..."
+                    $Session = New-PSSession -ComputerName $RemoteName -ConfigurationName PowerShell.7
+                    break
+                } else {
+                    # On Azure in 1ES Linux environments, remote powershell is not supported (yet).
+                    $Session = "NOT_SUPPORTED"
+                    Write-Host "Remote PowerShell is not supported in Azure 1ES Linux environments"
+                    break
+                }
+            }
+            try {
+                if ($isWindows) {
+                    $username = (Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon').DefaultUserName
+                    $password = (Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon').DefaultPassword | ConvertTo-SecureString -AsPlainText -Force
+                    $cred = New-Object System.Management.Automation.PSCredential ($username, $password)
+                    $Session = New-PSSession -ComputerName $RemoteName -Credential $cred -ConfigurationName PowerShell.7
+                } else {
+                    $Session = New-PSSession -HostName $RemoteName -UserName $UserName -SSHTransport
+                }
+                break
+            } catch {
+                Write-Host "Error $_"
+                $Attempts += 1
+                Start-Sleep -Seconds 10
+            }
+        }
+
+        if ($null -eq $Session) {
+            Write-GHError "Failed to create remote session"
+            exit 1
+        }
+
+    } else {
+        $Session = "NOT_SUPPORTED"
+        Write-Host "Remote PowerShell is not supported in this environment"
+    }
+    return $Session
+}
+
+function Copy-RepoToPeer {
+    param($Session)
+    $RemoteDir = $env:RemoteDir
+    if (!($Session -eq "NOT_SUPPORTED")) {
+        # Copy the artifacts to the peer.
+        Write-Host "Copying files to peer"
+        Invoke-Command -Session $Session -ScriptBlock {
+            if (Test-Path $Using:RemoteDir) {
+                Remove-Item -Force -Recurse $Using:RemoteDir | Out-Null
+            }
+            New-Item -ItemType Directory -Path $Using:RemoteDir -Force | Out-Null
+        }
+        Copy-Item -ToSession $Session -Path ./* -Destination "$RemoteDir" -Recurse
+        Copy-Item -ToSession $Session -Path ./src/manifest/MsQuic.wprp -Destination "$RemoteDir/scripts"
+    } else {
+        Write-Host "Not using remote powershell, assuming peer has checked out the repo."
+    }
 }


### PR DESCRIPTION
Add additional abstractions to Netperf-Lib to make life easier for MsQuic developers to utilize netperf so that a singular script can be used on both Azure / Lab environments without needing to worry about the nitty gritty details (such as remote powershell vs. customized remote cache).