### PR TITLE
Leverage Netperf Lab to Collect CI MEMORY dumps

### DIFF
--- a/.github/workflows/auto-reset-parent-or-child-lab-machine.yml
+++ b/.github/workflows/auto-reset-parent-or-child-lab-machine.yml
@@ -96,7 +96,8 @@ jobs:
           { parent-or-child: "child=rr1-netperf-06\\localadminuser",     vm-name: "netperf-windows-2022-server" },
           { parent-or-child: "parent=rr1-netperf-07\\localadminuser",    vm-name: "netperf-windows-2022-client" },
           { parent-or-child: "child=rr1-netperf-08\\localadminuser",     vm-name: "netperf-windows-2022-server" },
-          { parent-or-child: "parent=rr1-netperf-09\\localadminuser",    vm-name: "netperf-windows-2022-client" }
+          { parent-or-child: "parent=rr1-netperf-09\\localadminuser",    vm-name: "netperf-windows-2022-client" },
+          { parent-or-child: "rr1-netperf-15",                           vm-name: "kernel-bvt-runner" }
         ]
     runs-on:
       - self-hosted

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -16,105 +16,105 @@ on:
 permissions: write-all
 
 jobs:
-  # build-windows-kernel:
-  #   name: Build WinKernel
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       vec: [
-  #         { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
-  #       ]
-  #   uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml@main
-  #   with:
-  #     config: ${{ matrix.vec.config }}
-  #     plat: ${{ matrix.vec.plat }}
-  #     os: ${{ matrix.vec.os }}
-  #     arch: ${{ matrix.vec.arch }}
-  #     tls: ${{ matrix.vec.tls }}
-  #     build: ${{ matrix.vec.build }}
-  #     ref: ${{ inputs.ref || '' }}
+  build-windows-kernel:
+    name: Build WinKernel
+    strategy:
+      fail-fast: false
+      matrix:
+        vec: [
+          { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+        ]
+    uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml@main
+    with:
+      config: ${{ matrix.vec.config }}
+      plat: ${{ matrix.vec.plat }}
+      os: ${{ matrix.vec.os }}
+      arch: ${{ matrix.vec.arch }}
+      tls: ${{ matrix.vec.tls }}
+      build: ${{ matrix.vec.build }}
+      ref: ${{ inputs.ref || '' }}
 
-  # build-windows:
-  #   name: Build WinUser
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       vec: [
-  #         { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
-  #       ]
-  #   uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
-  #   with:
-  #     config: ${{ matrix.vec.config }}
-  #     plat: ${{ matrix.vec.plat }}
-  #     os: ${{ matrix.vec.os }}
-  #     arch: ${{ matrix.vec.arch }}
-  #     tls: ${{ matrix.vec.tls }}
-  #     sanitize: ${{ matrix.vec.sanitize }}
-  #     build: ${{ matrix.vec.build }}
-  #     ref: ${{ inputs.ref || '' }}
+  build-windows:
+    name: Build WinUser
+    strategy:
+      fail-fast: false
+      matrix:
+        vec: [
+          { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+        ]
+    uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
+    with:
+      config: ${{ matrix.vec.config }}
+      plat: ${{ matrix.vec.plat }}
+      os: ${{ matrix.vec.os }}
+      arch: ${{ matrix.vec.arch }}
+      tls: ${{ matrix.vec.tls }}
+      sanitize: ${{ matrix.vec.sanitize }}
+      build: ${{ matrix.vec.build }}
+      ref: ${{ inputs.ref || '' }}
 
-  # bvt-kernel:
-  #   name: BVT Kernel
-  #   needs: [build-windows, build-windows-kernel]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       vec: [
-  #         { config: "Debug", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" }
-  #       ]
-  #   runs-on:
-  #     - self-hosted
-  #     - Windows
-  #     - kernel-bvt
-  #     - kernel-bvt-ci
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-  #     with:
-  #       ref: ${{ inputs.ref || '' }}
-  #       repository: microsoft/msquic
-  #   - name: Download Build Artifacts
-  #     uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-  #     with: # note we always use binaries built on windows-2022.
-  #       name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
-  #       path: artifacts
-  #   - name: Download Build Artifacts for Testing From WinUser
-  #     uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-  #     with: # note we always use binaries built on windows-2022.
-  #       name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
-  #       path: artifacts
-  #   - name: Add git to path
-  #     run: |
-  #       ls
-  #       whoami
-  #       echo "C:\Program Files\Git\cmd" >> $env:GITHUB_PATH
-  #       $env:GITHUB_PATH -split ';' | ForEach-Object { Write-Host $_ }
-  #     shell: pwsh
-  #   - name: Prepare Machine
-  #     run: scripts/prepare-machine.ps1 -ForTest -ForKernel
-  #     shell: pwsh
-  #   - name: Install ETW Manifest
-  #     shell: pwsh
-  #     run: |
-  #       $MsQuicDll = ".\artifacts\bin\windows\${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}\msquic.dll"
-  #       $ManifestPath = ".\src\manifest\MsQuicEtw.man"
-  #       wevtutil.exe um $ManifestPath
-  #       wevtutil.exe im $ManifestPath /rf:$($MsQuicDll) /mf:$($MsQuicDll)
-  #   - name: Test
-  #     shell: pwsh
-  #     timeout-minutes: 90
-  #     run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter ${{ inputs.filter }}
-  #   - name: Upload on Failure
-  #     uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
-  #     if: failure()
-  #     with:
-  #       name: BVT-Kernel-${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}
-  #       path: artifacts
+  bvt-kernel:
+    name: BVT Kernel
+    needs: [build-windows, build-windows-kernel]
+    strategy:
+      fail-fast: false
+      matrix:
+        vec: [
+          { config: "Debug", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" }
+        ]
+    runs-on:
+      - self-hosted
+      - Windows
+      - kernel-bvt
+      - kernel-bvt-ci
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        ref: ${{ inputs.ref || '' }}
+        repository: microsoft/msquic
+    - name: Download Build Artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      with: # note we always use binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+        path: artifacts
+    - name: Download Build Artifacts for Testing From WinUser
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      with: # note we always use binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+        path: artifacts
+    - name: Add git to path
+      run: |
+        ls
+        whoami
+        echo "C:\Program Files\Git\cmd" >> $env:GITHUB_PATH
+        $env:GITHUB_PATH -split ';' | ForEach-Object { Write-Host $_ }
+      shell: pwsh
+    - name: Prepare Machine
+      run: scripts/prepare-machine.ps1 -ForTest -ForKernel
+      shell: pwsh
+    - name: Install ETW Manifest
+      shell: pwsh
+      run: |
+        $MsQuicDll = ".\artifacts\bin\windows\${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}\msquic.dll"
+        $ManifestPath = ".\src\manifest\MsQuicEtw.man"
+        wevtutil.exe um $ManifestPath
+        wevtutil.exe im $ManifestPath /rf:$($MsQuicDll) /mf:$($MsQuicDll)
+    - name: Test
+      shell: pwsh
+      timeout-minutes: 90
+      run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter ${{ inputs.filter }}
+    - name: Upload on Failure
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+      if: failure()
+      with:
+        name: BVT-Kernel-${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}
+        path: artifacts
 
   collect_crashdump_if_any:
     name: Collect Crashdump If Any
-    # needs: [bvt-kernel]
-    # if: failure()
+    needs: [bvt-kernel]
+    if: failure()
     runs-on:
       - self-hosted
       - Windows

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -28,7 +28,6 @@ jobs:
       tls: ${{ matrix.vec.tls }}
       build: ${{ matrix.vec.build }}
       ref: ${{ inputs.ref || '' }}
-      repo: msquic
 
   build-windows:
     name: Build WinUser
@@ -48,7 +47,6 @@ jobs:
       sanitize: ${{ matrix.vec.sanitize }}
       build: ${{ matrix.vec.build }}
       ref: ${{ inputs.ref || '' }}
-      repo: msquic
 
   bvt-kernel:
     name: BVT Kernel

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -78,9 +78,14 @@ jobs:
       with: # note we always use binaries built on windows-2022.
         name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
         path: artifacts
-    - name: Prepare Machine
+    - name: Sanity Check
+      run: |
+        ls
+        git
       shell: pwsh
+    - name: Prepare Machine
       run: scripts/prepare-machine.ps1 -ForTest -ForKernel
+      shell: pwsh
     - name: Install ETW Manifest
       shell: pwsh
       run: |

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -2,47 +2,100 @@ name: Custom Tasks
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'MsQuic Branch or Commit'
+        required: true
+        type: string
 
 permissions: write-all
 
 jobs:
-  download-artifacts:
-    name: Download artifacts
-    runs-on: windows-latest
+  build-windows-kernel:
+    name: Build WinKernel
+    strategy:
+      fail-fast: false
+      matrix:
+        vec: [
+          { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+        ]
+    uses: ./.github/workflows/build-reuse-winkernel.yml
+    with:
+      config: ${{ matrix.vec.config }}
+      plat: ${{ matrix.vec.plat }}
+      os: ${{ matrix.vec.os }}
+      arch: ${{ matrix.vec.arch }}
+      tls: ${{ matrix.vec.tls }}
+      build: ${{ matrix.vec.build }}
+      ref: ${{ inputs.ref || '' }}
+      repo: ${{ github.repository }}
+
+  build-windows:
+    name: Build WinUser
+    strategy:
+      fail-fast: false
+      matrix:
+        vec: [
+          { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+        ]
+    uses: ./.github/workflows/build-reuse-win.yml
+    with:
+      config: ${{ matrix.vec.config }}
+      plat: ${{ matrix.vec.plat }}
+      os: ${{ matrix.vec.os }}
+      arch: ${{ matrix.vec.arch }}
+      tls: ${{ matrix.vec.tls }}
+      sanitize: ${{ matrix.vec.sanitize }}
+      build: ${{ matrix.vec.build }}
+      ref: ${{ inputs.ref || '' }}
+      repo: ${{ github.repository }}
+
+  bvt-kernel:
+    name: BVT Kernel
+    needs: [build-windows, build-windows-kernel]
+    strategy:
+      fail-fast: false
+      matrix:
+        vec: [
+          { config: "Debug", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" }
+        ]
+    runs-on:
+      - self-hosted
+      - Windows
+      - kernel-bvt
     steps:
-      - name: Test download artifacts
-        run: |
-          $truth_table = @(
-            @{ dispatched_workflow_id = 10912645568 },
-            @{ dispatched_workflow_id = 10912540924 }
-          )
-          $github_headers = @{
-            "Accept" = "application/vnd.github+json"
-            "Authorization" = "Bearer ${{ secrets.GITHUB_TOKEN }}"
-            "X-GitHub-Api-Version" = "2022-11-28"
-          }
-
-          # Downloads all artifacts uploaded by the callee
-          mkdir -Force "artifacts"
-          foreach ($row in $truth_table) {
-            $callee_workflow_id = $row.dispatched_workflow_id
-            if ($callee_workflow_id) {
-              $artifacts_metadata_url = "https://api.github.com/repos/microsoft/netperf/actions/runs/$callee_workflow_id/artifacts"
-              Write-Host "Downloading artifacts for workflow ID: $callee_workflow_id"
-              $response = Invoke-WebRequest -Uri $artifacts_metadata_url -Headers $github_headers -Method Get
-              $json_response = $response.Content | ConvertFrom-Json
-              $json_response = $json_response.artifacts
-              foreach ($artifact in $json_response) {
-                $name = $artifact.name
-                $archive_download_url = $artifact.archive_download_url
-                $response = Invoke-WebRequest -Uri $archive_download_url -Headers $github_headers -Method Get -OutFile "$name.zip"
-                Expand-Archive -Path "$name.zip" -DestinationPath "artifacts" -Force
-              }
-            }
-          }
-        shell: pwsh
-      - name: List downloaded artifacts
-        run: |
-          Get-ChildItem -Path "artifacts" -Recurse
-        shell: pwsh
-
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        ref: ${{ inputs.ref || '' }}
+    - name: Download Build Artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      with: # note we always use binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+        path: artifacts
+    - name: Download Build Artifacts for Testing From WinUser
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      with: # note we always use binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+        path: artifacts
+    - name: Prepare Machine
+      shell: pwsh
+      run: scripts/prepare-machine.ps1 -ForTest -ForKernel
+    - name: Install ETW Manifest
+      shell: pwsh
+      run: |
+        $MsQuicDll = ".\artifacts\bin\windows\${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}\msquic.dll"
+        $ManifestPath = ".\src\manifest\MsQuicEtw.man"
+        wevtutil.exe um $ManifestPath
+        wevtutil.exe im $ManifestPath /rf:$($MsQuicDll) /mf:$($MsQuicDll)
+    - name: Test
+      shell: pwsh
+      timeout-minutes: 90
+      run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ClientCertificate*:*LoadBalanced*
+    - name: Upload on Failure
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+      if: failure()
+      with:
+        name: BVT-Kernel-${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}
+        path: artifacts
+        

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -11,46 +11,46 @@ on:
 permissions: write-all
 
 jobs:
-  build-windows-kernel:
-    name: Build WinKernel
-    strategy:
-      fail-fast: false
-      matrix:
-        vec: [
-          { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
-        ]
-    uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml@main
-    with:
-      config: ${{ matrix.vec.config }}
-      plat: ${{ matrix.vec.plat }}
-      os: ${{ matrix.vec.os }}
-      arch: ${{ matrix.vec.arch }}
-      tls: ${{ matrix.vec.tls }}
-      build: ${{ matrix.vec.build }}
-      ref: ${{ inputs.ref || '' }}
+  # build-windows-kernel:
+  #   name: Build WinKernel
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       vec: [
+  #         { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+  #       ]
+  #   uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml@main
+  #   with:
+  #     config: ${{ matrix.vec.config }}
+  #     plat: ${{ matrix.vec.plat }}
+  #     os: ${{ matrix.vec.os }}
+  #     arch: ${{ matrix.vec.arch }}
+  #     tls: ${{ matrix.vec.tls }}
+  #     build: ${{ matrix.vec.build }}
+  #     ref: ${{ inputs.ref || '' }}
 
-  build-windows:
-    name: Build WinUser
-    strategy:
-      fail-fast: false
-      matrix:
-        vec: [
-          { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
-        ]
-    uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
-    with:
-      config: ${{ matrix.vec.config }}
-      plat: ${{ matrix.vec.plat }}
-      os: ${{ matrix.vec.os }}
-      arch: ${{ matrix.vec.arch }}
-      tls: ${{ matrix.vec.tls }}
-      sanitize: ${{ matrix.vec.sanitize }}
-      build: ${{ matrix.vec.build }}
-      ref: ${{ inputs.ref || '' }}
+  # build-windows:
+  #   name: Build WinUser
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       vec: [
+  #         { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+  #       ]
+  #   uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
+  #   with:
+  #     config: ${{ matrix.vec.config }}
+  #     plat: ${{ matrix.vec.plat }}
+  #     os: ${{ matrix.vec.os }}
+  #     arch: ${{ matrix.vec.arch }}
+  #     tls: ${{ matrix.vec.tls }}
+  #     sanitize: ${{ matrix.vec.sanitize }}
+  #     build: ${{ matrix.vec.build }}
+  #     ref: ${{ inputs.ref || '' }}
 
   bvt-kernel:
     name: BVT Kernel
-    needs: [build-windows, build-windows-kernel]
+    # needs: [build-windows, build-windows-kernel]
     strategy:
       fail-fast: false
       matrix:
@@ -68,23 +68,22 @@ jobs:
       with:
         ref: ${{ inputs.ref || '' }}
         repository: microsoft/msquic
-    - name: Download Build Artifacts
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-      with: # note we always use binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
-        path: artifacts
-    - name: Download Build Artifacts for Testing From WinUser
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-      with: # note we always use binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
-        path: artifacts
+    # - name: Download Build Artifacts
+    #   uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+    #   with: # note we always use binaries built on windows-2022.
+    #     name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+    #     path: artifacts
+    # - name: Download Build Artifacts for Testing From WinUser
+    #   uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+    #   with: # note we always use binaries built on windows-2022.
+    #     name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+    #     path: artifacts
     - name: Sanity Check
       run: |
         ls
         whoami
         echo "C:\Program Files\Git\cmd" >> $env:GITHUB_PATH
-        echo "C:\Program Files\Git\cmd" >> $env:PATH
-        $env:PATH -split ';' | ForEach-Object { Write-Host $_ }
+        $env:GITHUB_PATH -split ';' | ForEach-Object { Write-Host $_ }
         git
       shell: pwsh
     - name: Prepare Machine

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -16,97 +16,123 @@ on:
 permissions: write-all
 
 jobs:
-  build-windows-kernel:
-    name: Build WinKernel
-    strategy:
-      fail-fast: false
-      matrix:
-        vec: [
-          { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
-        ]
-    uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml@main
-    with:
-      config: ${{ matrix.vec.config }}
-      plat: ${{ matrix.vec.plat }}
-      os: ${{ matrix.vec.os }}
-      arch: ${{ matrix.vec.arch }}
-      tls: ${{ matrix.vec.tls }}
-      build: ${{ matrix.vec.build }}
-      ref: ${{ inputs.ref || '' }}
+  # build-windows-kernel:
+  #   name: Build WinKernel
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       vec: [
+  #         { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+  #       ]
+  #   uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml@main
+  #   with:
+  #     config: ${{ matrix.vec.config }}
+  #     plat: ${{ matrix.vec.plat }}
+  #     os: ${{ matrix.vec.os }}
+  #     arch: ${{ matrix.vec.arch }}
+  #     tls: ${{ matrix.vec.tls }}
+  #     build: ${{ matrix.vec.build }}
+  #     ref: ${{ inputs.ref || '' }}
 
-  build-windows:
-    name: Build WinUser
-    strategy:
-      fail-fast: false
-      matrix:
-        vec: [
-          { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
-        ]
-    uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
-    with:
-      config: ${{ matrix.vec.config }}
-      plat: ${{ matrix.vec.plat }}
-      os: ${{ matrix.vec.os }}
-      arch: ${{ matrix.vec.arch }}
-      tls: ${{ matrix.vec.tls }}
-      sanitize: ${{ matrix.vec.sanitize }}
-      build: ${{ matrix.vec.build }}
-      ref: ${{ inputs.ref || '' }}
+  # build-windows:
+  #   name: Build WinUser
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       vec: [
+  #         { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+  #       ]
+  #   uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
+  #   with:
+  #     config: ${{ matrix.vec.config }}
+  #     plat: ${{ matrix.vec.plat }}
+  #     os: ${{ matrix.vec.os }}
+  #     arch: ${{ matrix.vec.arch }}
+  #     tls: ${{ matrix.vec.tls }}
+  #     sanitize: ${{ matrix.vec.sanitize }}
+  #     build: ${{ matrix.vec.build }}
+  #     ref: ${{ inputs.ref || '' }}
 
-  bvt-kernel:
-    name: BVT Kernel
-    needs: [build-windows, build-windows-kernel]
-    strategy:
-      fail-fast: false
-      matrix:
-        vec: [
-          { config: "Debug", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" }
-        ]
+  # bvt-kernel:
+  #   name: BVT Kernel
+  #   needs: [build-windows, build-windows-kernel]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       vec: [
+  #         { config: "Debug", plat: "winkernel", os: "WinServerPrerelease", arch: "x64", tls: "schannel", build: "-Test" }
+  #       ]
+  #   runs-on:
+  #     - self-hosted
+  #     - Windows
+  #     - kernel-bvt
+  #     - kernel-bvt-ci
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+  #     with:
+  #       ref: ${{ inputs.ref || '' }}
+  #       repository: microsoft/msquic
+  #   - name: Download Build Artifacts
+  #     uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+  #     with: # note we always use binaries built on windows-2022.
+  #       name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+  #       path: artifacts
+  #   - name: Download Build Artifacts for Testing From WinUser
+  #     uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+  #     with: # note we always use binaries built on windows-2022.
+  #       name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+  #       path: artifacts
+  #   - name: Add git to path
+  #     run: |
+  #       ls
+  #       whoami
+  #       echo "C:\Program Files\Git\cmd" >> $env:GITHUB_PATH
+  #       $env:GITHUB_PATH -split ';' | ForEach-Object { Write-Host $_ }
+  #     shell: pwsh
+  #   - name: Prepare Machine
+  #     run: scripts/prepare-machine.ps1 -ForTest -ForKernel
+  #     shell: pwsh
+  #   - name: Install ETW Manifest
+  #     shell: pwsh
+  #     run: |
+  #       $MsQuicDll = ".\artifacts\bin\windows\${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}\msquic.dll"
+  #       $ManifestPath = ".\src\manifest\MsQuicEtw.man"
+  #       wevtutil.exe um $ManifestPath
+  #       wevtutil.exe im $ManifestPath /rf:$($MsQuicDll) /mf:$($MsQuicDll)
+  #   - name: Test
+  #     shell: pwsh
+  #     timeout-minutes: 90
+  #     run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter ${{ inputs.filter }}
+  #   - name: Upload on Failure
+  #     uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+  #     if: failure()
+  #     with:
+  #       name: BVT-Kernel-${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}
+  #       path: artifacts
+
+  collect_crashdump_if_any:
+    name: Collect Crashdump If Any
+    # needs: [bvt-kernel]
+    # if: failure()
     runs-on:
       - self-hosted
       - Windows
       - kernel-bvt
       - kernel-bvt-ci
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      with:
-        ref: ${{ inputs.ref || '' }}
-        repository: microsoft/msquic
-    - name: Download Build Artifacts
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-      with: # note we always use binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
-        path: artifacts
-    - name: Download Build Artifacts for Testing From WinUser
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-      with: # note we always use binaries built on windows-2022.
-        name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
-        path: artifacts
-    - name: Add git to path
-      run: |
-        ls
-        whoami
-        echo "C:\Program Files\Git\cmd" >> $env:GITHUB_PATH
-        $env:GITHUB_PATH -split ';' | ForEach-Object { Write-Host $_ }
-      shell: pwsh
-    - name: Prepare Machine
-      run: scripts/prepare-machine.ps1 -ForTest -ForKernel
-      shell: pwsh
-    - name: Install ETW Manifest
-      shell: pwsh
-      run: |
-        $MsQuicDll = ".\artifacts\bin\windows\${{ matrix.vec.arch }}_${{ matrix.vec.config }}_${{ matrix.vec.tls }}\msquic.dll"
-        $ManifestPath = ".\src\manifest\MsQuicEtw.man"
-        wevtutil.exe um $ManifestPath
-        wevtutil.exe im $ManifestPath /rf:$($MsQuicDll) /mf:$($MsQuicDll)
-    - name: Test
-      shell: pwsh
-      timeout-minutes: 90
-      run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter ${{ inputs.filter }}
-    - name: Upload on Failure
-      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
-      if: failure()
-      with:
-        name: BVT-Kernel-${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}
-        path: artifacts
+      - name: Sanity Check
+        run: |
+          if (Test-Path 'C:\Windows\MEMORY.DMP') {
+            Write-Host "Crash dump found."
+            cp 'C:\Windows\MEMORY.DMP' .
+          } else {
+            Write-Host "No crash dump found."
+            exit 1
+          }
+        shell: pwsh
+      - name: Upload Crashdump
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        with:
+          name: memorydmp
+          path: MEMORY.DMP

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -19,7 +19,7 @@ jobs:
         vec: [
           { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
         ]
-    uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml
+    uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml@main
     with:
       config: ${{ matrix.vec.config }}
       plat: ${{ matrix.vec.plat }}
@@ -38,7 +38,7 @@ jobs:
         vec: [
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
         ]
-    uses: microsoft/msquic/.github/workflows/build-reuse-win.yml
+    uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
     with:
       config: ${{ matrix.vec.config }}
       plat: ${{ matrix.vec.plat }}

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -11,46 +11,46 @@ on:
 permissions: write-all
 
 jobs:
-  # build-windows-kernel:
-  #   name: Build WinKernel
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       vec: [
-  #         { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
-  #       ]
-  #   uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml@main
-  #   with:
-  #     config: ${{ matrix.vec.config }}
-  #     plat: ${{ matrix.vec.plat }}
-  #     os: ${{ matrix.vec.os }}
-  #     arch: ${{ matrix.vec.arch }}
-  #     tls: ${{ matrix.vec.tls }}
-  #     build: ${{ matrix.vec.build }}
-  #     ref: ${{ inputs.ref || '' }}
+  build-windows-kernel:
+    name: Build WinKernel
+    strategy:
+      fail-fast: false
+      matrix:
+        vec: [
+          { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+        ]
+    uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml@main
+    with:
+      config: ${{ matrix.vec.config }}
+      plat: ${{ matrix.vec.plat }}
+      os: ${{ matrix.vec.os }}
+      arch: ${{ matrix.vec.arch }}
+      tls: ${{ matrix.vec.tls }}
+      build: ${{ matrix.vec.build }}
+      ref: ${{ inputs.ref || '' }}
 
-  # build-windows:
-  #   name: Build WinUser
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       vec: [
-  #         { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
-  #       ]
-  #   uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
-  #   with:
-  #     config: ${{ matrix.vec.config }}
-  #     plat: ${{ matrix.vec.plat }}
-  #     os: ${{ matrix.vec.os }}
-  #     arch: ${{ matrix.vec.arch }}
-  #     tls: ${{ matrix.vec.tls }}
-  #     sanitize: ${{ matrix.vec.sanitize }}
-  #     build: ${{ matrix.vec.build }}
-  #     ref: ${{ inputs.ref || '' }}
+  build-windows:
+    name: Build WinUser
+    strategy:
+      fail-fast: false
+      matrix:
+        vec: [
+          { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
+        ]
+    uses: microsoft/msquic/.github/workflows/build-reuse-win.yml@main
+    with:
+      config: ${{ matrix.vec.config }}
+      plat: ${{ matrix.vec.plat }}
+      os: ${{ matrix.vec.os }}
+      arch: ${{ matrix.vec.arch }}
+      tls: ${{ matrix.vec.tls }}
+      sanitize: ${{ matrix.vec.sanitize }}
+      build: ${{ matrix.vec.build }}
+      ref: ${{ inputs.ref || '' }}
 
   bvt-kernel:
     name: BVT Kernel
-    # needs: [build-windows, build-windows-kernel]
+    needs: [build-windows, build-windows-kernel]
     strategy:
       fail-fast: false
       matrix:
@@ -68,25 +68,22 @@ jobs:
       with:
         ref: ${{ inputs.ref || '' }}
         repository: microsoft/msquic
-    # - name: Download Build Artifacts
-    #   uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-    #   with: # note we always use binaries built on windows-2022.
-    #     name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
-    #     path: artifacts
-    # - name: Download Build Artifacts for Testing From WinUser
-    #   uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-    #   with: # note we always use binaries built on windows-2022.
-    #     name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
-    #     path: artifacts
-    - name: Sanity Check
+    - name: Download Build Artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      with: # note we always use binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-${{ matrix.vec.plat }}-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+        path: artifacts
+    - name: Download Build Artifacts for Testing From WinUser
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      with: # note we always use binaries built on windows-2022.
+        name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
+        path: artifacts
+    - name: Add git to path
       run: |
         ls
         whoami
         echo "C:\Program Files\Git\cmd" >> $env:GITHUB_PATH
         $env:GITHUB_PATH -split ';' | ForEach-Object { Write-Host $_ }
-      shell: pwsh
-    - name: Sanity Check Pt 2
-      run: git
       shell: pwsh
     - name: Prepare Machine
       run: scripts/prepare-machine.ps1 -ForTest -ForKernel

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -19,7 +19,7 @@ jobs:
         vec: [
           { config: "Debug", plat: "winkernel", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
         ]
-    uses: ./.github/workflows/build-reuse-winkernel.yml
+    uses: microsoft/msquic/.github/workflows/build-reuse-winkernel.yml
     with:
       config: ${{ matrix.vec.config }}
       plat: ${{ matrix.vec.plat }}
@@ -38,7 +38,7 @@ jobs:
         vec: [
           { config: "Debug", plat: "windows", os: "windows-2022", arch: "x64", tls: "schannel", build: "-Test" }
         ]
-    uses: ./.github/workflows/build-reuse-win.yml
+    uses: microsoft/msquic/.github/workflows/build-reuse-win.yml
     with:
       config: ${{ matrix.vec.config }}
       plat: ${{ matrix.vec.plat }}
@@ -63,6 +63,7 @@ jobs:
       - self-hosted
       - Windows
       - kernel-bvt
+      - kernel-bvt-ci
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -98,4 +99,3 @@ jobs:
       with:
         name: BVT-Kernel-${{ matrix.vec.config }}-${{ matrix.vec.plat }}-${{ matrix.vec.os }}-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}
         path: artifacts
-        

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -28,7 +28,7 @@ jobs:
       tls: ${{ matrix.vec.tls }}
       build: ${{ matrix.vec.build }}
       ref: ${{ inputs.ref || '' }}
-      repo: ${{ github.repository }}
+      repo: msquic
 
   build-windows:
     name: Build WinUser
@@ -48,7 +48,7 @@ jobs:
       sanitize: ${{ matrix.vec.sanitize }}
       build: ${{ matrix.vec.build }}
       ref: ${{ inputs.ref || '' }}
-      repo: ${{ github.repository }}
+      repo: msquic
 
   bvt-kernel:
     name: BVT Kernel

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -7,6 +7,11 @@ on:
         description: 'MsQuic Branch or Commit'
         required: true
         type: string
+      filter:
+        description: 'Custom Test Filter'
+        default: '-*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ClientCertificate*:*LoadBalanced*'
+        required: false
+        type: string
 
 permissions: write-all
 
@@ -98,7 +103,7 @@ jobs:
     - name: Test
       shell: pwsh
       timeout-minutes: 90
-      run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter -*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ClientCertificate*:*LoadBalanced*
+      run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter ${{ inputs.filter }}
     - name: Upload on Failure
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
       if: failure()

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -67,6 +67,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         ref: ${{ inputs.ref || '' }}
+        repository: microsoft/msquic
     - name: Download Build Artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with: # note we always use binaries built on windows-2022.

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -78,27 +78,12 @@ jobs:
       with: # note we always use binaries built on windows-2022.
         name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
         path: artifacts
-    - name: Add Git to PATH
-      shell: pwsh
-      run: |
-        # Common install paths for Git on Windows
-        $candidates = @(
-          'C:\Program Files\Git\cmd',
-          'C:\Program Files\Git\bin',
-          "$env:USERPROFILE\scoop\shims",
-          "$env:USERPROFILE\AppData\Local\Programs\Git\cmd"
-        )
-        foreach ($p in $candidates) {
-          if (Test-Path $p) {
-            # Persist for the rest of the job
-            echo $p >> $env:GITHUB_PATH
-          }
-        }
-        git --version
     - name: Sanity Check
       run: |
         ls
         whoami
+        echo "C:\Program Files\Git\cmd" >> $env:GITHUB_PATH
+        echo "C:\Program Files\Git\cmd" >> $env:PATH
         $env:PATH -split ';' | ForEach-Object { Write-Host $_ }
         git
       shell: pwsh

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -78,6 +78,23 @@ jobs:
       with: # note we always use binaries built on windows-2022.
         name: ${{ matrix.vec.config }}-windows-windows-2022-${{ matrix.vec.arch }}-${{ matrix.vec.tls }}${{ matrix.vec.build }}
         path: artifacts
+    - name: Add Git to PATH
+      shell: pwsh
+      run: |
+        # Common install paths for Git on Windows
+        $candidates = @(
+          'C:\Program Files\Git\cmd',
+          'C:\Program Files\Git\bin',
+          "$env:USERPROFILE\scoop\shims",
+          "$env:USERPROFILE\AppData\Local\Programs\Git\cmd"
+        )
+        foreach ($p in $candidates) {
+          if (Test-Path $p) {
+            # Persist for the rest of the job
+            echo $p >> $env:GITHUB_PATH
+          }
+        }
+        git --version
     - name: Sanity Check
       run: |
         ls

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -81,6 +81,8 @@ jobs:
     - name: Sanity Check
       run: |
         ls
+        whoami
+        $env:PATH -split ';' | ForEach-Object { Write-Host $_ }
         git
       shell: pwsh
     - name: Prepare Machine

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -84,7 +84,9 @@ jobs:
         whoami
         echo "C:\Program Files\Git\cmd" >> $env:GITHUB_PATH
         $env:GITHUB_PATH -split ';' | ForEach-Object { Write-Host $_ }
-        git
+      shell: pwsh
+    - name: Sanity Check Pt 2
+      run: git
       shell: pwsh
     - name: Prepare Machine
       run: scripts/prepare-machine.ps1 -ForTest -ForKernel

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -138,3 +138,4 @@ jobs:
         with:
           name: memorydmp
           path: MEMORY.DMP
+  

--- a/.github/workflows/msquic_kernel_bvt.yml
+++ b/.github/workflows/msquic_kernel_bvt.yml
@@ -1,4 +1,4 @@
-name: Custom Tasks
+name: MsQuic Kernel BVT
 
 on:
   workflow_dispatch:
@@ -34,7 +34,7 @@ jobs:
       arch: ${{ matrix.vec.arch }}
       tls: ${{ matrix.vec.tls }}
       build: ${{ matrix.vec.build }}
-      ref: ${{ inputs.ref || '' }}
+      ref: ${{ github.event.client_payload.ref || inputs.ref || '' }}
 
   build-windows:
     name: Build WinUser
@@ -53,7 +53,7 @@ jobs:
       tls: ${{ matrix.vec.tls }}
       sanitize: ${{ matrix.vec.sanitize }}
       build: ${{ matrix.vec.build }}
-      ref: ${{ inputs.ref || '' }}
+      ref: ${{ github.event.client_payload.ref || inputs.ref || '' }}
 
   bvt-kernel:
     name: BVT Kernel
@@ -73,7 +73,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
-        ref: ${{ inputs.ref || '' }}
+        ref: ${{ github.event.client_payload.ref || inputs.ref || '' }}
         repository: microsoft/msquic
     - name: Download Build Artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
@@ -105,7 +105,7 @@ jobs:
     - name: Test
       shell: pwsh
       timeout-minutes: 90
-      run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter ${{ inputs.filter }}
+      run: scripts/test.ps1 -Config ${{ matrix.vec.config }} -Arch ${{ matrix.vec.arch }} -Tls ${{ matrix.vec.tls }} -OsRunner ${{ matrix.vec.os }} -GHA -LogProfile Full.Light -GenerateXmlResults -Kernel -Filter ${{ github.event.client_payload.filter || inputs.filter || '' }}
     - name: Upload on Failure
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
       if: failure()

--- a/.github/workflows/msquic_kernel_bvt.yml
+++ b/.github/workflows/msquic_kernel_bvt.yml
@@ -155,3 +155,11 @@ jobs:
         with:
           name: memorydmp
           path: MEMORY.DMP
+
+  attempt-reset-lab:
+    name: Attempting to reset lab. Status of this job does not indicate result of lab reset. Look at job details.
+    needs: [collect_crashdump_if_any]
+    if: ${{ success() }}
+    uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
+    with:
+      workflowId: ${{ github.run_id }}

--- a/.github/workflows/msquic_kernel_bvt.yml
+++ b/.github/workflows/msquic_kernel_bvt.yml
@@ -18,6 +18,23 @@ on:
 permissions: write-all
 
 jobs:
+  # For automated identification of the workflow.
+  name:
+    if: ${{ github.event_name == 'repository_dispatch' }}
+    name: For ${{ github.event.client_payload.guid }}
+    needs: []
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Print Parameters
+      run: |
+        echo "Parameters from repository_dispatch:"
+        echo "guid: ${{ github.event.client_payload.guid }}"
+        echo "sha: ${{ github.event.client_payload.sha }}"
+        echo "ref: ${{ github.event.client_payload.ref }}"
+        echo "pr: ${{ github.event.client_payload.pr }}"
+        echo "logs: ${{ github.event.client_payload.logs }}"
+        echo "filter: ${{ github.event.client_payload.filter }}"
+
   build-windows-kernel:
     name: Build WinKernel
     strategy:

--- a/.github/workflows/msquic_kernel_bvt.yml
+++ b/.github/workflows/msquic_kernel_bvt.yml
@@ -9,8 +9,7 @@ on:
         type: string
       filter:
         description: 'Custom Test Filter'
-        default: '-*ValidateConfiguration:*ValidAlpnLengths:*ResumeRejection*:*ClientCertificate*:*LoadBalanced*'
-        required: false
+        required: true
         type: string
     repository_dispatch:
       types: [run-msquic-kernel-bvt]


### PR DESCRIPTION
Netperf, in addition to measuring performance data on MsQuic, should also be able to run MsQuic functional CI (a subset) in Kernel mode and collect crash dumps for analysis.

We can leverage this pattern for the XDP-for-windows project too.

Validation: 
https://github.com/microsoft/netperf/actions/runs/18208239591,

which ran on MsQuic Ref: https://github.com/microsoft/msquic/compare/main...jackhe/bugcheck-on-purpose

<img width="589" height="306" alt="image" src="https://github.com/user-attachments/assets/4ae7cfce-fc34-4d1e-bac2-6717d7ff6f6e" />

<img width="1888" height="1506" alt="image" src="https://github.com/user-attachments/assets/346b4a82-91f9-477d-80f9-22fbd2929ed3" />


Here is another run which doesn't run on an MsQuic version that does not bugcheck:

https://github.com/microsoft/netperf/actions/runs/18206803000