### PR TITLE
Update GitHub Actions checkout and download artifact versions

### DIFF
--- a/.github/workflows/network-traffic-performance.yml
+++ b/.github/workflows/network-traffic-performance.yml
@@ -96,7 +96,7 @@ jobs:
         SENDER_OPTIONS: ${{ inputs.sender_options }}
         RECEIVER_OPTIONS: ${{ inputs.receiver_options }}
       shell: pwsh
-      run: .\\run-traffic-test.ps1 -PeerName "netperf-peer" -SenderOptions "${{ inputs.sender_options }}" -ReceiverOptions "${{ inputs.receiver_options }}"
+      run: .\\run-traffic-test.ps1 ${{ inputs.profile == 'true' && '-Profile' || '' }} -PeerName "netperf-peer" -SenderOptions "${{ inputs.sender_options }}" -ReceiverOptions "${{ inputs.receiver_options }}"
 
     - name: Upload CTS results
       if: always()


### PR DESCRIPTION
This pull request updates the `network-traffic-performance.yml` GitHub Actions workflow to improve script versioning, dependency management, and input handling. The most significant changes include removing the `peername` input, ensuring scripts are always downloaded from the correct ref, and updating action versions for improved reliability.

**Workflow input and environment changes:**

* Removed the `peername` input from the workflow, simplifying the required inputs and hardcoding the peer name in the test script invocation. [[1]](diffhunk://#diff-a6078b7994ccd7b6797b28f14d26cd5f2df0115cc8376c134e3f0bddbc22eec9L30-L33) [[2]](diffhunk://#diff-a6078b7994ccd7b6797b28f14d26cd5f2df0115cc8376c134e3f0bddbc22eec9L88-R99)

**Script and dependency management improvements:**

* Updated the download URL for the `tcpip.wprp` file to use the `${{inputs.ref}}` variable, ensuring the workflow always uses the correct version of the script matching the workflow's ref.
* Added a new step to download the `run-traffic-test.ps1` script dynamically from the `${{inputs.ref}}` branch, ensuring the test script matches the current workflow version.

**Action version updates:**

* Updated the `actions/checkout` action to a newer commit for improved reliability.
* Added an explicit version comment for the `actions/download-artifact` action for clarity.