### PR TITLE
ci: fix tcpip tracing step

### DIFF
--- a/.github/scripts/run-traffic-test.ps1
+++ b/.github/scripts/run-traffic-test.ps1
@@ -2,7 +2,7 @@ param(
   [switch]$Profile,
   [string]$PeerName,
   [string]$SenderOptions,
-  [string]$ReceiverOptions
+  [string]$ReceiverOptions,
   [string]$TimeoutInMilliseconds = '300000'
 )
 

--- a/.github/workflows/network-traffic-performance.yml
+++ b/.github/workflows/network-traffic-performance.yml
@@ -108,8 +108,9 @@ jobs:
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: cts_traffic_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
-        path: ${{ github.workspace }}\cts-traffic\*.csv
-        path: ${{ github.workspace }}\cts-traffic\*.log
+        path: |
+          ${{ github.workspace }}\cts-traffic\*.csv
+          ${{ github.workspace }}\cts-traffic\*.log
 
     - name: Upload TCPIP ETL
       if: ${{ github.event.inputs.tcp_ip_tracing == 'true' && always() }}


### PR DESCRIPTION
Ensure tcp_ip_tracing input is checked as a string 'true' before starting WPR and avoid passing string values to PowerShell switches.