### PR TITLE
Fix peername instead of local computer name

### DIFF
--- a/.github/scripts/run-traffic-test.ps1
+++ b/.github/scripts/run-traffic-test.ps1
@@ -255,7 +255,7 @@ try {
   #
   $serverArgs = Parse-Args $SenderOptions
   # When the remote is the sender, ensure it targets the local machine (receiver)
-  $serverArgs = Ensure-TargetArg -ArgsArray $serverArgs -TargetName $env:COMPUTERNAME
+  $serverArgs = Ensure-TargetArg -ArgsArray $serverArgs -TargetName $PeerName
   # Normalize server args: ensure each explicit option starts with '-'
   $serverArgs = $serverArgs | ForEach-Object {
     if ([string]::IsNullOrEmpty($_)) { $_ } else { if ($_ -like '-*') { $_ } else { '-' + $_ } }


### PR DESCRIPTION
This pull request updates the logic in the PowerShell script responsible for configuring traffic test arguments. The main change is to ensure that the sender targets the correct peer machine, rather than always defaulting to the local machine.

**Traffic test configuration update:**

* Modified the assignment of the `-TargetName` argument in `.github/scripts/run-traffic-test.ps1` to use `$PeerName` instead of `$env:COMPUTERNAME`, ensuring the sender targets the intended peer machine during remote tests.