### PR TITLE
Remove excessive permissions in workflow

### DIFF
--- a/.github/workflows/schedule-lab-reset.yml
+++ b/.github/workflows/schedule-lab-reset.yml
@@ -8,9 +8,6 @@ on:
         required: true
         type: string
 
-
-permissions: write-all
-
 jobs:
   attempt-lab-reset:
     name: Enqueue Lab Reset Workflow


### PR DESCRIPTION
The workflow that just calls `api.github.com` requires no permissions at all. This was slop that slipped through boilerplate copy-pasting.