### PR TITLE
Add WinQuicEcho (QUIC echo) variant to network-traffic-performance

### DIFF
--- a/.github/scripts/performance_utilities.psm1
+++ b/.github/scripts/performance_utilities.psm1
@@ -221,6 +221,14 @@ function Invoke-ToolInSession {
     [int]$WaitSeconds = 0
   )
 
+  # Parse options into array on the local side to avoid needing
+  # Convert-ArgStringToArray in the remote session (it's not available there).
+  # This also eliminates duplicated parsing logic.
+  if ($Options -and $Options -isnot [System.Array]) {
+    $Options = Convert-ArgStringToArray $Options
+  }
+  if (-not $Options) { $Options = @() }
+
   $Job = Invoke-Command -Session $Session -ScriptBlock {
     param($RemoteDir, $ToolDir, $ToolName, $Options, $WaitSeconds)
 
@@ -242,15 +250,19 @@ function Invoke-ToolInSession {
 
     Write-Host "[Remote] Running: $Tool"
     if ($Options -is [System.Array]) {
-      Write-Host "[Remote] Arguments (array):"
+      Write-Host "[Remote] Arguments (array, $($Options.Count) tokens):"
       foreach ($arg in $Options) { Write-Host "  $arg" }
       $argList = $Options
     }
     else {
-      Write-Host "[Remote] Arguments (string):"
+      # Options should always arrive as an array (parsed on local side).
+      # If PS remoting flattened it to a single string, treat it as one token.
+      Write-Host "[Remote] Arguments (single string token):"
       Write-Host "  $Options"
       $argList = @()
-      if (-not [string]::IsNullOrEmpty($Options)) { $argList = @($Options) }
+      if (-not [string]::IsNullOrEmpty($Options)) {
+        $argList = @($Options)
+      }
     }
     
     try {

--- a/.github/scripts/run-quic-echo-test.ps1
+++ b/.github/scripts/run-quic-echo-test.ps1
@@ -1,0 +1,668 @@
+param(
+  [switch]$CpuProfile,
+  [string]$PeerName,
+  [string]$SenderOptions,
+  [string]$ReceiverOptions,
+  [string]$Duration = "60"
+)
+
+Set-StrictMode -Version Latest
+
+# Import shared utilities module
+function Find-RepoRoot {
+  param(
+    [Parameter(Mandatory = $true)][string]$StartDir
+  )
+
+  if (Test-Path -LiteralPath $StartDir) {
+    $item = Get-Item -LiteralPath $StartDir
+    if ($item.PSIsContainer) {
+      $dir = $item.FullName
+    }
+    else {
+      $dir = $item.DirectoryName
+    }
+  }
+  else {
+    $dir = $StartDir
+  }
+  while ($true) {
+    if (Test-Path -LiteralPath (Join-Path $dir '.git')) {
+      return $dir
+    }
+
+    $parent = Split-Path -Parent $dir
+    if (-not $parent -or $parent -eq $dir) {
+      return $null
+    }
+    $dir = $parent
+  }
+}
+
+$scriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+$moduleName = 'performance_utilities.psm1'
+$twoLevelsUp = Join-Path $scriptDir '..\..'
+$moduleCandidates = @(
+  (Join-Path $scriptDir $moduleName),
+  (Join-Path $scriptDir '..' $moduleName),
+  (Join-Path $twoLevelsUp $moduleName)
+)
+
+if ($env:GITHUB_WORKSPACE) {
+  $githubScriptsDir = Join-Path $env:GITHUB_WORKSPACE '.github\scripts'
+  $moduleCandidates += (Join-Path $githubScriptsDir $moduleName)
+}
+
+$repoRoot = Find-RepoRoot -StartDir $scriptDir
+if ($repoRoot) {
+  $repoScriptsDir = Join-Path $repoRoot '.github\scripts'
+  $moduleCandidates += (Join-Path $repoScriptsDir $moduleName)
+}
+
+$modulePath = $moduleCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+if (-not $modulePath) {
+  $moduleCandidatesString = ($moduleCandidates | ForEach-Object { "  $_" }) -join [Environment]::NewLine
+  Write-Error -ErrorAction Stop -Message ("Could not find required module '{0}'. Tried:{1}{2}" -f $moduleName, [Environment]::NewLine, $moduleCandidatesString)
+}
+
+Import-Module $modulePath -Force
+
+# Write out the parameters for logging
+Write-Host "Parameters:"
+Write-Host "  CpuProfile: $CpuProfile"
+Write-Host "  PeerName: $PeerName"
+Write-Host "  SenderOptions: $SenderOptions"
+Write-Host "  ReceiverOptions: $ReceiverOptions"
+Write-Host "  Duration: $Duration"
+
+# Ensure --backend msquic is present in sender (client) options
+if ($SenderOptions -notmatch '--backend') {
+  $SenderOptions += " --backend msquic"
+}
+
+# Ensure --server is in the sender/client options
+if ($SenderOptions -notmatch '--server') {
+  $SenderOptions += " --server $PeerName"
+}
+
+# Ensure --insecure is in the sender/client options for benchmark convenience
+if ($SenderOptions -notmatch '--insecure') {
+  $SenderOptions += " --insecure"
+}
+
+# Ensure --backend msquic is present in receiver (server) options
+if ($ReceiverOptions -notmatch '--backend') {
+  $ReceiverOptions += " --backend msquic"
+}
+
+# Validate and parse duration up-front
+$durationInt = 60
+if ($Duration) {
+  if (-not [int]::TryParse($Duration, [ref]$durationInt) -or $durationInt -le 0) {
+    throw "Invalid duration '$Duration': must be a positive integer (seconds)"
+  }
+}
+
+# Compute timeout with buffer for startup/cleanup overhead
+$script:processTimeoutMs = ($durationInt + 60) * 1000
+$script:jobTimeoutSec    = $durationInt + 120
+
+# Add duration option if not already present
+if ($SenderOptions -notmatch '--duration') {
+  $SenderOptions += " --duration $durationInt"
+}
+if ($ReceiverOptions -notmatch '--duration') {
+  $ReceiverOptions += " --duration $durationInt"
+}
+
+$ErrorActionPreference = 'Stop'
+$Session = $null
+$exitCode = 0
+$script:serverProc = $null
+$script:cpuMonitorJob = $null
+$script:perfCounterJob = $null
+$localFwState = $null
+$localCertThumbprint = $null
+$remoteCertThumbprint = $null
+
+function Write-Phase {
+  param([Parameter(Mandatory=$true)][string]$Message)
+  Write-Host "[$(Get-Date -Format o)] $Message"
+}
+
+function Wait-JobWithProgress {
+  param(
+    [Parameter(Mandatory=$true)]$Job,
+    [Parameter(Mandatory=$true)][string]$Name,
+    [int]$TimeoutSeconds = 15,
+    [int]$MaxSeconds = 0
+  )
+
+  if ($MaxSeconds -le 0) { $MaxSeconds = $script:jobTimeoutSec }
+
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  while ($true) {
+    if ($sw.Elapsed.TotalSeconds -ge $MaxSeconds) {
+      $sw.Stop()
+      Stop-Job -Job $Job -ErrorAction SilentlyContinue
+      throw "TIMEOUT: $Name did not complete within ${MaxSeconds}s"
+    }
+    $completed = Wait-Job -Job $Job -Timeout $TimeoutSeconds
+    if ($completed) { break }
+
+    $state = $Job.JobStateInfo.State
+    Write-Phase "Still waiting on $Name (JobId=$($Job.Id), State=$state, Elapsed=$([Math]::Round($sw.Elapsed.TotalSeconds, 0))s)"
+  }
+
+  $sw.Stop()
+  $state = $Job.JobStateInfo.State
+  Write-Phase "$Name completed (JobId=$($Job.Id), State=$state, Elapsed=$([Math]::Round($sw.Elapsed.TotalSeconds, 2))s)"
+}
+
+function New-QuicDevCert {
+  <#
+    .SYNOPSIS
+    Creates a self-signed certificate for WinQuicEcho in the CurrentUser\My store
+    and returns the thumbprint. Cleans up any stale certs from prior runs first.
+  #>
+  # Remove stale certs from interrupted prior runs
+  Get-ChildItem Cert:\CurrentUser\My | Where-Object { $_.FriendlyName -eq 'WinQuicEcho Dev Cert' } | ForEach-Object {
+    Write-Host "Removing stale local dev cert: $($_.Thumbprint)"
+    Remove-Item "Cert:\CurrentUser\My\$($_.Thumbprint)" -Force -ErrorAction SilentlyContinue
+  }
+  $cert = New-SelfSignedCertificate `
+      -DnsName "localhost" `
+      -CertStoreLocation "Cert:\CurrentUser\My" `
+      -FriendlyName "WinQuicEcho Dev Cert" `
+      -NotAfter (Get-Date).AddHours(2) `
+      -KeyAlgorithm RSA `
+      -KeyLength 2048 `
+      -HashAlgorithm SHA256
+  Write-Host "Created dev certificate: $($cert.Thumbprint)"
+  return $cert.Thumbprint
+}
+
+function New-RemoteQuicDevCert {
+  <#
+    .SYNOPSIS
+    Creates a self-signed certificate on the remote machine via PS remoting.
+    Returns the thumbprint. Cleans up stale certs from prior runs first.
+  #>
+  param(
+    [Parameter(Mandatory=$true)]$Session
+  )
+  $thumbprint = Invoke-Command -Session $Session -ScriptBlock {
+    # Remove stale certs from interrupted prior runs
+    Get-ChildItem Cert:\CurrentUser\My | Where-Object { $_.FriendlyName -eq 'WinQuicEcho Dev Cert' } | ForEach-Object {
+      Write-Host "Removing stale remote dev cert: $($_.Thumbprint)"
+      Remove-Item "Cert:\CurrentUser\My\$($_.Thumbprint)" -Force -ErrorAction SilentlyContinue
+    }
+    $cert = New-SelfSignedCertificate `
+        -DnsName "localhost" `
+        -CertStoreLocation "Cert:\CurrentUser\My" `
+        -FriendlyName "WinQuicEcho Dev Cert" `
+        -NotAfter (Get-Date).AddHours(2) `
+        -KeyAlgorithm RSA `
+        -KeyLength 2048 `
+        -HashAlgorithm SHA256
+    return $cert.Thumbprint
+  }
+  Write-Host "Created remote dev certificate: $thumbprint"
+  return $thumbprint
+}
+
+function Remove-QuicDevCert {
+  <#
+    .SYNOPSIS
+    Removes WinQuicEcho dev certificates from CurrentUser\My store by thumbprint.
+  #>
+  param([string]$Thumbprint)
+  if ($Thumbprint) {
+    try {
+      $certPath = "Cert:\CurrentUser\My\$Thumbprint"
+      if (Test-Path $certPath) {
+        Remove-Item $certPath -Force
+        Write-Host "Removed local dev certificate: $Thumbprint"
+      }
+    } catch {
+      Write-Warning "Failed to remove local dev certificate: $($_.Exception.Message)"
+    }
+  }
+}
+
+function Remove-RemoteQuicDevCert {
+  <#
+    .SYNOPSIS
+    Removes WinQuicEcho dev certificates from the remote machine.
+  #>
+  param(
+    [Parameter(Mandatory=$true)]$Session,
+    [string]$Thumbprint
+  )
+  if ($Thumbprint -and $Session) {
+    try {
+      Invoke-Command -Session $Session -ArgumentList $Thumbprint -ScriptBlock {
+        param($tp)
+        $certPath = "Cert:\CurrentUser\My\$tp"
+        if (Test-Path $certPath) {
+          Remove-Item $certPath -Force
+        }
+      }
+      Write-Host "Removed remote dev certificate: $Thumbprint"
+    } catch {
+      Write-Warning "Failed to remove remote dev certificate: $($_.Exception.Message)"
+    }
+  }
+}
+
+function Wait-JobWithTimeout {
+  <#
+    .SYNOPSIS
+    Waits for a job to complete within a timeout.
+    Returns $true if completed, $false if timed out.
+  #>
+  param(
+    [Parameter(Mandatory=$true)]$Job,
+    [Parameter(Mandatory=$true)][string]$Name,
+    [int]$TimeoutSeconds = 300
+  )
+
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  while ($sw.Elapsed.TotalSeconds -lt $TimeoutSeconds) {
+    $completed = Wait-Job -Job $Job -Timeout 15
+    if ($completed) {
+      Write-Phase "$Name job completed (State=$($Job.State), Elapsed=$([Math]::Round($sw.Elapsed.TotalSeconds))s)"
+      return $true
+    }
+    Write-Phase "Still waiting on $Name (State=$($Job.State), Elapsed=$([Math]::Round($sw.Elapsed.TotalSeconds))s)"
+  }
+
+  Write-Phase "TIMEOUT: $Name did not complete within ${TimeoutSeconds}s — stopping job"
+  Stop-Job -Job $Job -ErrorAction SilentlyContinue
+  return $false
+}
+
+# Safely stops a remote PS job and kills the associated native process on the remote host.
+function Stop-RemoteJobAndProcess {
+  param(
+    [Parameter(Mandatory=$true)]$Job,
+    [Parameter(Mandatory=$true)]$Session,
+    [Parameter(Mandatory=$true)][string]$ProcessName
+  )
+  try {
+    if ($Job.State -eq 'Running') {
+      Stop-Job -Job $Job -ErrorAction SilentlyContinue
+    }
+    Invoke-Command -Session $Session -ScriptBlock {
+      param($name)
+      Get-Process -Name $name -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    } -ArgumentList $ProcessName
+  } catch {
+    Write-Warning "Failed to clean up remote ${ProcessName}: $_"
+  }
+}
+
+function Run-SendTest {
+  param(
+    [Parameter(Mandatory=$true)][string]$PeerName,
+    [Parameter(Mandatory=$true)]$Session,
+    [Parameter(Mandatory=$true)][string]$SenderOptions,
+    [Parameter(Mandatory=$true)][string]$ReceiverOptions,
+    [Parameter(Mandatory=$true)][string]$RemoteCertThumbprint
+  )
+
+  # Server runs on remote — add cert-hash for the remote cert
+  $serverArgs = Convert-ArgStringToArray $ReceiverOptions
+  $serverArgs = Normalize-Args -Tokens $serverArgs
+  $serverArgs += @('--cert-hash', $RemoteCertThumbprint, '--verbose')
+  Write-Host "[Local->Remote] Invoking remote echo_server with arguments:"
+  if ($serverArgs -is [System.Array]) { foreach ($arg in $serverArgs) { Write-Host "  $arg" } } else { Write-Host "  $serverArgs" }
+  $Job = Invoke-ToolInSession -Session $Session -RemoteDir $script:RemoteDir -ToolDir 'quic_echo' -ToolName "echo_server" -Options $serverArgs -WaitSeconds 0
+
+  try {
+    # Give the server a moment to start listening before the client connects
+    Write-Phase "Waiting 5s for remote echo_server to initialize..."
+    Start-Sleep -Seconds 5
+
+    # Client runs locally
+    $clientArgs = Convert-ArgStringToArray $SenderOptions
+    $clientArgs = Normalize-Args -Tokens $clientArgs
+    $clientArgs += @('--stats-file', 'quic_echo_client_stats.json', '--verbose')
+
+    Write-Host "[Local] Running: .\echo_client.exe"
+    Write-Host "[Local] Arguments:"
+    foreach ($a in $clientArgs) { Write-Host "  $a" }
+    Start-WprCpuProfile -Which 'send' -CpuProfile:$CpuProfile
+    try {
+      & .\echo_client.exe @clientArgs
+      $script:localExit = $LASTEXITCODE
+      Write-Phase "Local echo_client exited with code $script:localExit"
+    } finally {
+      Stop-WprCpuProfile -Which 'send' -CpuProfile:$CpuProfile
+    }
+    if ($script:localExit -ne 0) { throw "Local echo_client exited with non-zero code $script:localExit" }
+
+    Write-Phase "Waiting for remote echo_server job to complete..."
+    $serverCompleted = Wait-JobWithTimeout -Job $Job -Name 'Remote echo_server (send)' -TimeoutSeconds $script:jobTimeoutSec
+    $null = Receive-Job $Job -Keep -ErrorAction SilentlyContinue
+    # Drain remote output for diagnostics
+    foreach ($cj in $Job.ChildJobs) {
+      foreach ($line in $cj.Output) { Write-Host "[Remote stdout] $line" }
+      foreach ($line in $cj.Error) { Write-Host "[Remote stderr] $line" }
+    }
+    if (-not $serverCompleted) {
+      Write-Warning "Remote echo_server timed out (likely MsQuic cleanup hang). Client exit code: $script:localExit"
+      if ($script:localExit -ne 0) {
+        throw "Client failed with exit code $script:localExit AND server timed out"
+      }
+    } else {
+      $errs = @()
+      foreach ($cj in $Job.ChildJobs) {
+        if ($cj.JobStateInfo.State -eq 'Failed' -and $cj.JobStateInfo.Reason) {
+          $errs += $cj.JobStateInfo.Reason
+        }
+      }
+      if ($errs.Count -gt 0) { throw "Remote echo_server errors: $($errs -join '; ')" }
+    }
+  } finally {
+    # Always clean up the remote server job/process regardless of success or failure
+    Stop-RemoteJobAndProcess -Job $Job -Session $Session -ProcessName 'echo_server'
+  }
+}
+
+function Run-RecvTest {
+  param(
+    [Parameter(Mandatory=$true)][string]$PeerName,
+    [Parameter(Mandatory=$true)]$Session,
+    [Parameter(Mandatory=$true)][string]$SenderOptions,
+    [Parameter(Mandatory=$true)][string]$ReceiverOptions,
+    [Parameter(Mandatory=$true)][string]$LocalCertThumbprint
+  )
+
+  # Server runs locally — start first so it's listening before the client connects
+  $serverArgs = Convert-ArgStringToArray $ReceiverOptions
+  $serverArgs = Normalize-Args -Tokens $serverArgs
+  $serverArgs += @('--cert-hash', $LocalCertThumbprint, '--verbose')
+
+  Write-Host "[Local] Running: .\echo_server.exe (background process)"
+  Write-Host "[Local] Arguments:"
+  foreach ($a in $serverArgs) { Write-Host "  $a" }
+  Start-WprCpuProfile -Which 'recv' -CpuProfile:$CpuProfile
+  try {
+    $serverExe = (Resolve-Path .\echo_server.exe).Path
+    $script:serverProc = Start-Process -FilePath $serverExe -ArgumentList $serverArgs -PassThru -NoNewWindow
+
+    # Give the server time to start listening
+    Write-Phase "Waiting 5s for local echo_server to initialize..."
+    Start-Sleep -Seconds 5
+
+    # Client runs on remote
+    $clientArgs = Convert-ArgStringToArray $SenderOptions
+    $clientArgs = Normalize-Args -Tokens $clientArgs
+    $clientArgs += @('--verbose')
+    Write-Host "[Local->Remote] Invoking remote echo_client with arguments:"
+    if ($clientArgs -is [System.Array]) { foreach ($arg in $clientArgs) { Write-Host "  $arg" } } else { Write-Host "  $clientArgs" }
+    $Job = Invoke-ToolInSession -Session $Session -RemoteDir $script:RemoteDir -ToolDir 'quic_echo' -ToolName "echo_client" -Options $clientArgs -WaitSeconds 0
+
+    # Wait for local server to finish (it exits after --duration)
+    Write-Phase "Waiting for local echo_server process to exit..."
+    $serverTimedOut = $false
+    if (-not $script:serverProc.WaitForExit($script:processTimeoutMs)) {
+      Write-Warning "Local echo_server did not exit within $($script:processTimeoutMs / 1000)s — killing process (PID $($script:serverProc.Id))"
+      Stop-Process -Id $script:serverProc.Id -Force -ErrorAction SilentlyContinue
+      $script:serverProc.WaitForExit(5000)
+      $serverTimedOut = $true
+    }
+    # Refresh process object to ensure ExitCode is available after kill
+    $script:serverProc.Refresh()
+    $script:localExit = if ($serverTimedOut) { -1 } else { $script:serverProc.ExitCode }
+    Write-Phase "Local echo_server exited with code $script:localExit (timedOut=$serverTimedOut)"
+  } finally {
+    Stop-WprCpuProfile -Which 'recv' -CpuProfile:$CpuProfile
+  }
+
+  # Wrap server-exit checks and remote job wait in try/finally to ensure the
+  # remote echo_client job/process is always cleaned up, even when the local
+  # server fails or times out.
+  try {
+    if ($serverTimedOut) { throw "Local echo_server timed out after $($script:processTimeoutMs / 1000)s" }
+    if ($script:localExit -ne 0) { throw "Local echo_server exited with non-zero code $script:localExit" }
+
+    Write-Phase "Waiting for remote echo_client job to complete..."
+    $clientCompleted = Wait-JobWithTimeout -Job $Job -Name 'Remote echo_client (recv)' -TimeoutSeconds $script:jobTimeoutSec
+    $null = Receive-Job $Job -Keep -ErrorAction SilentlyContinue
+    foreach ($cj in $Job.ChildJobs) {
+      foreach ($line in $cj.Output) { Write-Host "[Remote stdout] $line" }
+      foreach ($line in $cj.Error) { Write-Host "[Remote stderr] $line" }
+    }
+    if (-not $clientCompleted) {
+      Write-Warning "Remote echo_client timed out. Local server exit code: $script:localExit"
+      if ($script:localExit -ne 0) {
+        throw "Local server failed with exit code $script:localExit AND remote client timed out"
+      }
+    } else {
+      $errs = @()
+      foreach ($cj in $Job.ChildJobs) {
+        if ($cj.JobStateInfo.State -eq 'Failed' -and $cj.JobStateInfo.Reason) {
+          $errs += $cj.JobStateInfo.Reason
+        }
+      }
+      if ($errs.Count -gt 0) { throw "Remote echo_client errors: $($errs -join '; ')" }
+    }
+  } finally {
+    Stop-RemoteJobAndProcess -Job $Job -Session $Session -ProcessName 'echo_client'
+  }
+}
+
+$PerformanceCounters =
+@(
+  '\UDPv4\Datagrams Received Errors',
+  '\UDPv6\Datagrams Received Errors',
+
+  '\Network Interface(*)\Packets Received Errors',
+  '\Network Interface(*)\Packets Received Discarded',
+  '\Network Interface(*)\Packets Outbound Discarded',
+
+  '\IPv4\Datagrams Received Discarded',
+  '\IPv4\Datagrams Received Header Errors',
+  '\IPv4\Datagrams Received Address Errors',
+
+  '\IPv6\Datagrams Received Discarded',
+  '\IPv6\Datagrams Received Header Errors',
+  '\IPv6\Datagrams Received Address Errors',
+
+  '\Processor Information(*)\% Processor Time'
+)
+
+# =========================
+# Main workflow
+# =========================
+try {
+
+  $cwd = (Get-Location).Path
+  Write-Host "[$(Get-Date -Format o)] Current working directory: $cwd"
+
+  Get-NetAdapterRss
+
+  Write-Host "[$(Get-Date -Format o)] Starting QUIC echo tests to peer '$PeerName' with duration $durationInt seconds..."
+
+  # Create remote session
+  $Session = Create-Session -PeerName $PeerName -RemotePSConfiguration 'PowerShell.7'
+
+  $script:RemoteDir = 'C:\_work'
+  $script:RemotePSConfiguration = 'PowerShell.7'
+
+  # Save and disable firewalls
+  Save-And-Disable-Firewalls -Session $Session
+
+  # Copy tool to remote
+  Copy-ToolDirToRemote -Session $Session -RemoteDir $script:RemoteDir -ToolDir 'quic_echo'
+
+  # Diagnostic: verify executables and msquic.dll are present locally and remotely
+  Write-Phase "Verifying local tool files..."
+  @('echo_server.exe', 'echo_client.exe', 'msquic.dll') | ForEach-Object {
+    $exists = Test-Path $_
+    Write-Host "  $_ : $(if ($exists) { 'FOUND' } else { 'MISSING' })"
+    if (-not $exists) { throw "Required file $_ not found in $(Get-Location)" }
+  }
+  Write-Phase "Verifying remote tool files..."
+  Invoke-Command -Session $Session -ScriptBlock {
+    param($dir)
+    $toolDir = Join-Path $dir 'quic_echo'
+    Write-Host "  Remote tool directory: $toolDir"
+    Get-ChildItem $toolDir | ForEach-Object { Write-Host "    $($_.Name) ($($_.Length) bytes)" }
+  } -ArgumentList $script:RemoteDir
+
+  # Generate dev certificates on both local and remote machines
+  Write-Phase "Generating dev certificates for QUIC TLS"
+  $localCertThumbprint = New-QuicDevCert
+  $remoteCertThumbprint = New-RemoteQuicDevCert -Session $Session
+
+  # ---- Send phase ----
+  Write-Phase "Starting CPU/perf counter jobs (send phase)"
+  $script:cpuMonitorJob = CaptureIndividualCpuUsagePerformanceMonitorAsJob -DurationSeconds $durationInt
+  $script:perfCounterJob = CapturePerformanceMonitorAsJob -DurationSeconds $durationInt -Counters $PerformanceCounters
+
+  Write-Phase "Starting send test"
+  Run-SendTest -PeerName $PeerName -Session $Session -SenderOptions $SenderOptions -ReceiverOptions $ReceiverOptions -RemoteCertThumbprint $remoteCertThumbprint
+  Write-Phase "Send test finished"
+
+  Write-Phase "Waiting for CPU monitor job (send phase)"
+  Wait-JobWithProgress -Job $script:cpuMonitorJob -Name 'CPU monitor (send)'
+  $cpuUsagePerCpu = Receive-Job -Job $script:cpuMonitorJob -Wait -AutoRemoveJob
+  $script:cpuMonitorJob = $null
+  if ($cpuUsagePerCpu -is [System.Array]) {
+    $i = 0
+    foreach ($val in $cpuUsagePerCpu) {
+      $i++
+      Write-Host "CPU$i $([math]::Round([double]$val, 2)) %"
+    }
+    $overall = (($cpuUsagePerCpu | Measure-Object -Average).Average)
+    Write-Host "Overall average CPU Usage: $([math]::Round($overall, 2)) %"
+  }
+  else {
+    Write-Host "CPU1 $([math]::Round([double]$cpuUsagePerCpu, 2)) %"
+  }
+
+  Write-Phase "Waiting for perf counter job (send phase)"
+  Wait-JobWithProgress -Job $script:perfCounterJob -Name 'Perf counters (send)'
+  $perfResults = Receive-Job -Job $script:perfCounterJob -Wait -AutoRemoveJob
+  $script:perfCounterJob = $null
+  $perfJsonPath = Join-Path $cwd 'quic_echo_client_perf_counters.json'
+  $perfResults | ConvertTo-Json | Out-File -FilePath $perfJsonPath -Encoding utf8 -Force
+  Write-Phase "Perf counter JSON written (send phase): $perfJsonPath"
+
+  # ---- Recv phase ----
+  Write-Phase "Starting CPU/perf counter jobs (recv phase)"
+  $script:cpuMonitorJob = CaptureIndividualCpuUsagePerformanceMonitorAsJob -DurationSeconds $durationInt
+  $script:perfCounterJob = CapturePerformanceMonitorAsJob -DurationSeconds $durationInt -Counters $PerformanceCounters
+
+  Write-Phase "Starting recv test"
+  Run-RecvTest -PeerName $PeerName -Session $Session -SenderOptions $SenderOptions -ReceiverOptions $ReceiverOptions -LocalCertThumbprint $localCertThumbprint
+  Write-Phase "Recv test finished"
+
+  Write-Phase "Waiting for CPU monitor job (recv phase)"
+  Wait-JobWithProgress -Job $script:cpuMonitorJob -Name 'CPU monitor (recv)'
+  $cpuUsagePerCpu = Receive-Job -Job $script:cpuMonitorJob -Wait -AutoRemoveJob
+  $script:cpuMonitorJob = $null
+  if ($cpuUsagePerCpu -is [System.Array]) {
+    $i = 0
+    foreach ($val in $cpuUsagePerCpu) {
+      $i++
+      Write-Host "CPU$i $([math]::Round([double]$val, 2)) %"
+    }
+    $overall = (($cpuUsagePerCpu | Measure-Object -Average).Average)
+    Write-Host "Overall average CPU Usage: $([math]::Round($overall, 2)) %"
+  }
+  else {
+    Write-Host "CPU1 $([math]::Round([double]$cpuUsagePerCpu, 2)) %"
+  }
+
+  Write-Phase "Waiting for perf counter job (recv phase)"
+  Wait-JobWithProgress -Job $script:perfCounterJob -Name 'Perf counters (recv)'
+  $perfResults = Receive-Job -Job $script:perfCounterJob -Wait -AutoRemoveJob
+  $script:perfCounterJob = $null
+  $perfJsonPath = Join-Path $cwd 'quic_echo_server_perf_counters.json'
+  $perfResults | ConvertTo-Json | Out-File -FilePath $perfJsonPath -Encoding utf8 -Force
+  Write-Phase "Perf counter JSON written (recv phase): $perfJsonPath"
+
+  # List json files in cwd
+  Write-Host "JSON files in $cwd"
+  # Log JSON file names and sizes (full contents available in uploaded artifacts)
+  Get-ChildItem -Path $cwd -Filter *.json | ForEach-Object {
+    Write-Host "  $($_.FullName) ($($_.Length) bytes)"
+  }
+
+  # Copy stats files to parent folder for GitHub Actions artifact upload
+  if (Test-Path *.json) {
+    Copy-Item -Path *.json -Destination $cwd\.. -Force
+  }
+  else {
+    Write-Host "No JSON files found to copy."
+  }
+
+  Write-Host "QUIC echo tests completed successfully."
+}
+catch {
+  Write-Host "QUIC echo tests failed."
+  Write-Host $_
+  $exitCode = 2
+}
+finally {
+    # Best-effort WPR cancel in case inner try/finally was bypassed
+    try { & wpr -cancel 2>$null } catch { }
+
+    # Kill the specific local echo_server process if it's still running
+    if ($script:serverProc -and -not $script:serverProc.HasExited) {
+      Write-Warning "Cleaning up lingering echo_server (PID $($script:serverProc.Id))"
+      Stop-Process -Id $script:serverProc.Id -Force -ErrorAction SilentlyContinue
+    }
+
+    # Stop any lingering CPU/perf counter background jobs
+    foreach ($j in @($script:cpuMonitorJob, $script:perfCounterJob)) {
+      if ($j -and $j.State -eq 'Running') {
+        Write-Warning "Stopping leftover background job (Id=$($j.Id), Name=$($j.Name))"
+        Stop-Job -Job $j -ErrorAction SilentlyContinue
+        Remove-Job -Job $j -Force -ErrorAction SilentlyContinue
+      }
+    }
+
+    # Clean up dev certificates
+    Remove-QuicDevCert -Thumbprint $localCertThumbprint
+    if ($Session) {
+      Remove-RemoteQuicDevCert -Session $Session -Thumbprint $remoteCertThumbprint
+    }
+
+    Restore-FirewallAndCleanup -Session $Session
+    Write-Host "Exiting with code $exitCode"
+    exit $exitCode
+}
+
+<#
+  Troubleshooting notes for PowerShell Remoting errors:
+
+  - Add remote host to TrustedHosts (run as Administrator on the client):
+    ```powershell
+    Set-Item WSMan:\localhost\Client\TrustedHosts -Value "alanjo-test-2" -Force
+    # or allow all (less secure):
+    Set-Item WSMan:\localhost\Client\TrustedHosts -Value "*" -Force
+    ```
+
+  - Enable WinRM on the remote machine (run as Administrator on the remote):
+    ```powershell
+    Enable-PSRemoting -Force
+    Set-Service WinRM -StartupType Automatic
+    Start-Service WinRM
+    ```
+
+  - If using PowerShell 7 session configuration, register it on the remote:
+    ```powershell
+    Register-PSSessionConfiguration -Name PowerShell.7 -RunAsCredential (Get-Credential) -Force
+    ```
+
+  - For HTTPS transport, create an HTTPS listener and configure an SSL cert
+    for WinRM on the remote.  See `about_Remote_Troubleshooting`.
+
+  Note: Adding hosts to TrustedHosts weakens authentication; prefer HTTPS or
+  domain-joined Kerberos where possible.
+#>

--- a/.github/workflows/network-traffic-performance.yml
+++ b/.github/workflows/network-traffic-performance.yml
@@ -32,6 +32,7 @@ on:
         required: false
         default: 'main'
         type: string
+
       test_tool:
         description: 'The network test tool to use'
         required: false
@@ -40,6 +41,7 @@ on:
         options:
           - ctsTraffic
           - echo
+          - quicEcho
       duration:
         description: 'Duration of the test in seconds'
         required: false
@@ -403,6 +405,242 @@ jobs:
     name: Attempting to reset lab (ctsTraffic). Status of this job does not indicate result of lab reset. Look at job details.
     needs: [test_cts_traffic]
     if: ${{ always() && inputs.test_tool == 'ctsTraffic' }}
+    permissions:
+      actions: write
+    uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
+    with:
+      workflowId: ${{ github.run_id }}
+
+  build_quic_echo:
+    if: ${{ inputs.test_tool == 'quicEcho' }}
+    name: Build QUIC echo
+    permissions:
+      contents: read
+      actions: write
+    # WARNING: This uses a personal GitHub account (Alan-Jowett) instead of an organization repo.
+    # Consider migrating to an organization-owned repository to avoid maintenance risks if the
+    # personal account becomes unavailable. For now, this is the authoritative source for the
+    # WinQuicEcho tool.
+    uses: Alan-Jowett/WinQuicEcho/.github/workflows/reusable-build.yml@e1e18b718d6d5798bbbf2de38409397d7f940864
+    with:
+      artifact_name: quic_echo_test
+      config: 'Release'
+      # Pinned to the same audited commit as the workflow ref to prevent
+      # arbitrary code execution via user-controlled inputs.
+      ref: 'e1e18b718d6d5798bbbf2de38409397d7f940864'
+
+  test_quic_echo:
+    if: ${{ inputs.test_tool == 'quicEcho' }}
+    name: Network Traffic Test (QUIC echo)
+    needs: [build_quic_echo]
+    strategy:
+      fail-fast: false
+      matrix:
+        vec:
+          - env: lab
+            os: "2022"
+            arch: x64
+    runs-on:
+      - self-hosted
+      - ${{ matrix.vec.env }}
+      - os-windows-${{ matrix.vec.os }}
+      - ${{ matrix.vec.arch }}
+      - ebpf
+
+    steps:
+    - name: Pre-clean leftover PktMon artifacts
+      shell: pwsh
+      run: |
+        $workspace = "${{ github.workspace }}"
+
+        try { pktmon stop | Out-Null } catch { }
+        try { pktmon reset | Out-Null } catch { }
+        Start-Sleep -Seconds 2
+
+        try {
+          $p = Join-Path $workspace 'pktmon.etl'
+          if (Test-Path -LiteralPath $p) {
+            Remove-Item -LiteralPath $p -Force -ErrorAction Stop
+            Write-Host "Removed leftover file: $p"
+          }
+        } catch {
+          Write-Warning "Failed to remove leftover file '$p': $($_.Exception.Message)"
+        }
+
+    - name: Checkout repository
+      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+
+    - name: Setup workspace
+      run: |-
+        $currentDir = (Get-Location).Path
+        $expectedDir = "${{ github.workspace }}"
+        if ($currentDir -ne $expectedDir) {
+          Write-Error "Safety check failed: Current directory '$currentDir' does not match expected workspace '$expectedDir'. Aborting cleanup."
+          exit 1
+        }
+
+        Get-ChildItem  | % { Remove-Item -Recurse $_ -Force -ErrorAction SilentlyContinue }
+        if (Test-Path ${{ github.workspace }}\quic_echo) { Remove-Item -Recurse -Force ${{ github.workspace }}\quic_echo }
+        if (Test-Path ${{ github.workspace }}\ETL) { Remove-Item -Recurse -Force ${{ github.workspace }}\ETL }
+        New-Item -ItemType Directory -Path ${{ github.workspace }}\quic_echo\Release
+        New-Item -ItemType Directory -Path ${{ github.workspace }}\ETL
+
+    - name: Configure Windows Error Reporting to make a local copy of any crashes that occur.
+      id: configure_windows_error_reporting
+      run: |
+        $DumpFolder = "${{ github.workspace }}\quic_echo\dumps"
+        New-Item -Path $DumpFolder -ItemType Directory -Force | Out-Null
+        New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -ErrorAction SilentlyContinue
+        New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpType" -Value 2 -PropertyType DWord -ErrorAction SilentlyContinue
+        New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpFolder" -Value "$DumpFolder" -PropertyType ExpandString -ErrorAction SilentlyContinue
+
+    - name: Download QUIC echo test tool
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        name: "quic_echo_test"
+        path: ${{ github.workspace }}\quic_echo
+
+    - name: Optional - Start TCPIP tracing
+      if: ${{ github.event.inputs.tcp_ip_tracing == 'true' }}
+      run: |-
+        if (Test-Path "tcpip.wprp") { Remove-Item -Force "tcpip.wprp" }
+        Invoke-WebRequest -uri "https://raw.githubusercontent.com/microsoft/netperf/${{inputs.ref}}/.github/workflows/tcpip.wprp" -OutFile "tcpip.wprp"
+        wpr -start tcpip.wprp -filemode
+
+    - name: Download modified CPU profile script
+      working-directory: ${{ github.workspace }}\ETL
+      run: |
+        Invoke-WebRequest -uri "https://raw.githubusercontent.com/microsoft/netperf/${{inputs.ref}}/.github/scripts/cpu.wprp" -OutFile "${{ github.workspace }}\ETL\cpu.wprp"
+
+    - name: Download run-quic-echo-test script
+      working-directory: ${{ github.workspace }}\quic_echo\Release
+      run: |
+        Invoke-WebRequest -uri "https://raw.githubusercontent.com/microsoft/netperf/${{github.sha}}/.github/scripts/run-quic-echo-test.ps1" -OutFile ".\run-quic-echo-test.ps1"
+        Invoke-WebRequest -uri "https://raw.githubusercontent.com/microsoft/netperf/${{github.sha}}/.github/scripts/performance_utilities.psm1" -OutFile ".\performance_utilities.psm1"
+
+    - name: Log all input parameters for this workflow
+      run: |
+        Write-Output "Input parameters:"
+        Write-Output "  Profile: ${{ inputs.profile }}"
+        Write-Output "  SenderOptions: ${{ inputs.sender_options }}"
+        Write-Output "  ReceiverOptions: ${{ inputs.receiver_options }}"
+        Write-Output "  TCP IP Tracing: ${{ inputs.tcp_ip_tracing }}"
+        Write-Output "  ref: ${{ inputs.ref }}"
+        Write-Output "  Duration: ${{ inputs.duration }}"
+
+    - name: Diagnostic - List files in quic_echo Release directory
+      run: |
+        Write-Output "Files in quic_echo Release directory:"
+        Get-ChildItem -Path ${{ github.workspace }}\quic_echo\Release -Recurse
+
+    - name: Log pktmon drop counters before test
+      run: |
+        pktmon comp counters --type drop
+
+    - name: Start PktMon drop Capture
+      run: |
+        pktmon filter add -p 7
+        pktmon filter list
+        pktmon start --etw -c
+
+    - name: Run traffic tests
+      working-directory: ${{ github.workspace }}\quic_echo\Release
+      env:
+        PROFILE: ${{ inputs.profile }}
+        SENDER_OPTIONS: ${{ inputs.sender_options }}
+        RECEIVER_OPTIONS: ${{ inputs.receiver_options }}
+      shell: pwsh
+      run: |
+        $scriptPath = '.\run-quic-echo-test.ps1'
+
+        $params = @{
+          PeerName = 'netperf-peer'
+          SenderOptions = $env:SENDER_OPTIONS
+          ReceiverOptions = $env:RECEIVER_OPTIONS
+          Duration = '${{ inputs.duration }}'
+        }
+
+        if ($env:PROFILE -eq 'true' -or $env:PROFILE -eq 'True' -or $env:PROFILE -eq 'TRUE' -or $env:PROFILE -eq $true) {
+          $params.CpuProfile = $true
+        }
+
+        Write-Output "Running: $scriptPath with parameters:"
+        $params.GetEnumerator() | Sort-Object Name | ForEach-Object { Write-Output "  $($_.Name)=$($_.Value)" }
+
+        & $scriptPath @params
+
+    - name: Stop PktMon drop Capture
+      if: always()
+      run: |
+        pktmon stop
+        if (Test-Path pktmon.etl) {
+          copy pktmon.etl ${{ github.workspace }}\ETL\pktmon_drop_trace.etl
+          try {
+            Remove-Item -LiteralPath "${{ github.workspace }}\pktmon.etl" -Force -ErrorAction Stop
+          } catch {
+            Write-Warning "Failed to remove pktmon.etl: $($_.Exception.Message)"
+          }
+        } else {
+          Write-Warning "pktmon.etl not found - capture may not have started"
+        }
+        pktmon reset
+        pktmon filter remove all
+
+    - name: Log pktmon drop counters after test
+      if: always()
+      run: |
+        pktmon comp counters --type drop
+
+    - name: Optional - Stop TCPIP tracing
+      if: ${{ github.event.inputs.tcp_ip_tracing == 'true' }}
+      run: |
+        wpr -stop ${{ github.workspace }}\ETL\tcpip_trace.etl
+
+    - name: Upload QUIC echo results
+      if: always()
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      with:
+        name: quic_echo_test_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
+        path: |
+          ${{ github.workspace }}\quic_echo\*.csv
+          ${{ github.workspace }}\quic_echo\*.log
+          ${{ github.workspace }}\quic_echo\*.json
+
+    - name: Upload TCPIP ETL
+      if: always()
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      with:
+        name: tcpip_trace_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
+        path: ${{ github.workspace }}\ETL\tcpip_trace.etl
+
+    - name: Upload CPU Profile
+      if:  always()
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      with:
+        name: cpu_profile_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
+        path: ${{ github.workspace }}\ETL\cpu_profile-*.etl
+
+    - name: Upload PktMon Drop ETL
+      if:  always()
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      with:
+        name: pktmon_drop_trace_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
+        path: ${{ github.workspace }}\ETL\pktmon_drop_trace.etl
+
+    - name: Upload Crash Dumps
+      if:  always()
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+      with:
+        name: crash_dumps_${{ matrix.vec.env }}_${{ matrix.vec.os }}_${{ matrix.vec.arch }}
+        path: |
+          ${{ github.workspace }}\quic_echo\dumps
+
+  attempt-reset-lab-quic-echo:
+    name: Attempting to reset lab (quicEcho). Status of this job does not indicate result of lab reset. Look at job details.
+    needs: [test_quic_echo]
+    if: ${{ always() && inputs.test_tool == 'quicEcho' }}
+    permissions:
+      actions: write
     uses: microsoft/netperf/.github/workflows/schedule-lab-reset.yml@main
     with:
       workflowId: ${{ github.run_id }}


### PR DESCRIPTION
## Summary

Adds a QUIC-based echo performance test using [WinQuicEcho](https://github.com/Alan-Jowett/WinQuicEcho) (MsQuic datagram mode) alongside the existing UDP echo test.

## Changes

- **.github/scripts/run-quic-echo-test.ps1** (new) — Test script handling cert creation, server/client lifecycle with watchdog timeouts, stats collection, and cleanup
- **.github/workflows/network-traffic-performance.yml** — Added `quic-echo-build` and `quic-echo-test-windows` jobs using WinQuicEcho's reusable build workflow (static CRT)
- **.github/scripts/performance_utilities.psm1** — Fixed `Invoke-ToolInSession` to properly split string arguments into token arrays for PS remoting

## Test Results (lab VM-03-04, 8 connections × 64B payload × 30s)

| Metric | UDP Echo | QUIC Echo | Delta |
|--------|----------|-----------|-------|
| Requests/sec | 2,563 | 8,482 | **3.3× ↑** |
| Throughput (Mbps) | 1.64 | 4.34 | **2.6× ↑** |
| Latency avg | 0.18 ms | 0.79 ms | 4.4× (expected TLS overhead) |
| Drop rate | 1.31% | ~0.003% | **~400× ↓** |

## Validation

- ✅ QUIC echo build + test passing: [run 23021888940](https://github.com/microsoft/netperf/actions/runs/23021888940)
- ✅ UDP echo baseline passing: [run 23021419912](https://github.com/microsoft/netperf/actions/runs/23021419912)
- ✅ Code review fixes applied (exit code checks, server-before-client ordering in RecvTest)