### PR TITLE
Replace XDP MSI installer with NuGet-based xdp-setup.ps1

### DIFF
--- a/.github/workflows/ebpf.yml
+++ b/.github/workflows/ebpf.yml
@@ -110,7 +110,14 @@ jobs:
     steps:
     - name: Setup workspace
       run: |
+        # Uninstall XDP using xdp-setup.ps1 if available from a previous run.
+        $xdpSetup = "${{ github.workspace }}\xdp\xdp_runtime\runtime\native\xdp-setup.ps1"
+        if (Test-Path $xdpSetup) {
+          try { & $xdpSetup -Uninstall xdpebpf -Force -Verbose } catch { Write-Warning "XDP eBPF uninstall failed: $_" }
+          try { & $xdpSetup -Uninstall xdp -Force -Verbose } catch { Write-Warning "XDP uninstall failed: $_" }
+        }
         Get-ChildItem  | % { Remove-Item -Recurse $_ }
+        # Legacy MSI cleanup for backward compatibility with older installations.
         $process = Start-Process -FilePath "msiexec" -ArgumentList "/x {022C44B5-8969-4B75-8DB0-73F98B1BD7DC} /quiet /qn /norestart /log uninstall.log" -Wait -NoNewWindow
         $process = Start-Process -FilePath "msiexec" -ArgumentList "/x {9363C0E3-4DE9-4067-9F5E-6A1A06034B59} /quiet /qn /norestart /log uninstall.log" -Wait -NoNewWindow
         $url = "https://raw.githubusercontent.com/microsoft/ebpf-for-windows/main/scripts/Cleanup-Installer.ps1"
@@ -233,29 +240,32 @@ jobs:
     - name: Install xdp-for-windows
       working-directory: ${{ github.workspace }}\xdp
       run: |
-          cd ${{ github.workspace }}\\xdp\x64_Release
+          $artifactsDir = "${{ github.workspace }}\xdp\x64_Release"
+          cd $artifactsDir
+
+          # Install test signing certificate from the driver catalog.
           $CertFileName = 'xdp.cer'
-          Get-AuthenticodeSignature 'xdp.sys' | Select-Object -ExpandProperty SignerCertificate | Export-Certificate -Type CERT -FilePath $CertFileName
+          Get-AuthenticodeSignature 'xdp\xdp.cat' | Select-Object -ExpandProperty SignerCertificate | Export-Certificate -Type CERT -FilePath $CertFileName
           Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\root'
           Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher'
-          $installPath = "${{ github.workspace }}\xdp\x64_release"
-          Write-Output "xdp installPath: $installPath"
-          Write-Output "Installing XDP for Windows"
-          $xdpMsi = (get-item .\xdp-for-windows.x64.*.msi).Name
-          $process = Start-Process msiexec.exe -Wait -ArgumentList "/i $xdpMsi INSTALLFOLDER=$installPath /qn /log ${{ github.workspace }}\xdp\xdp_install.log ADDLOCAL=xdp_ebpf" -PassThru
-          if ($process.ExitCode -ne 0) { Get-Content ${{ github.workspace }}\xdp\xdp_install.log; exit $process.ExitCode }
+
+          # Find and extract the XDP runtime NuGet package.
+          $nupkg = (Get-ChildItem "packages\Microsoft.XDP-for-Windows.Runtime.x64.*.nupkg" | Select-Object -First 1).FullName
+          Write-Output "Found XDP runtime nupkg: $nupkg"
+          $xdpInstallPath = "${{ github.workspace }}\xdp\xdp_runtime"
+          Copy-Item -Path $nupkg -Destination "$nupkg.zip"
+          Expand-Archive -Path "$nupkg.zip" -DestinationPath $xdpInstallPath
+          Remove-Item -Path "$nupkg.zip"
+
+          # Install XDP using xdp-setup.ps1 from the extracted NuGet package.
+          $xdpSetup = "$xdpInstallPath\runtime\native\xdp-setup.ps1"
+          Write-Output "Installing XDP for Windows using $xdpSetup"
+          & $xdpSetup -Install xdp -Verbose
+          Write-Output "Installing XDP eBPF support"
+          & $xdpSetup -Install xdpebpf -Verbose
+
           Write-Output "XDP for Windows installed"
           sc.exe query xdp
-          reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XdpEbpfEnabled /d 1 /t REG_DWORD /f
-          sc.exe stop xdp
-          sc.exe start xdp
-
-    - name: Upload xdp-for-windows logs
-      if: always()
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-      with:
-        name: xdp-for-windows-logs
-        path: ${{ github.workspace }}\xdp\xdp_install.log
 
     - name: Download bpf_performance repository artifacts
       working-directory: ${{ github.workspace }}\bpf_performance
@@ -448,6 +458,13 @@ jobs:
     - name: Cleanup workspace
       if: always()
       run: |
+        # Uninstall XDP using xdp-setup.ps1 if available.
+        $xdpSetup = "${{ github.workspace }}\xdp\xdp_runtime\runtime\native\xdp-setup.ps1"
+        if (Test-Path $xdpSetup) {
+          try { & $xdpSetup -Uninstall xdpebpf -Force -Verbose } catch { Write-Warning "XDP eBPF uninstall failed: $_" }
+          try { & $xdpSetup -Uninstall xdp -Force -Verbose } catch { Write-Warning "XDP uninstall failed: $_" }
+        }
+        # Legacy MSI cleanup for backward compatibility with older installations.
         $process = Start-Process -FilePath "msiexec" -ArgumentList "/x {022C44B5-8969-4B75-8DB0-73F98B1BD7DC} /quiet /qn /norestart /log uninstall.log" -Wait -NoNewWindow
         $process = Start-Process -FilePath "msiexec" -ArgumentList "/x {9363C0E3-4DE9-4067-9F5E-6A1A06034B59} /quiet /qn /norestart /log uninstall.log" -Wait -NoNewWindow
         $url = "https://raw.githubusercontent.com/microsoft/ebpf-for-windows/main/scripts/Cleanup-Installer.ps1"


### PR DESCRIPTION
The XDP team removed MSI support in microsoft/xdp-for-windows#1014 (merged May 6, 2026). This updates the ebpf workflow to use the new NuGet-based installation method:

## Changes
- **Install**: Extract the XDP runtime NuGet package from build artifacts, then use `xdp-setup.ps1 -Install xdp` and `xdp-setup.ps1 -Install xdpebpf`
- **Cleanup**: Use `xdp-setup.ps1 -Uninstall` before legacy MSI cleanup (kept for backward compatibility)
- **Setup**: Uninstall XDP via xdp-setup.ps1 before wiping workspace (handles leftover installs from prior runs)
- **Removed**: MSI install log upload (no longer applicable)

## Test Results
Workflow run: https://github.com/microsoft/netperf/actions/runs/25813284591

The XDP install step succeeded - the xdp service is running. The workflow failure is a pre-existing disk space issue on the self-hosted runner (unrelated to this change).