### PR TITLE
feat: add rs_iof kernel mode msquic perf tests

### DIFF
--- a/.github/scripts/run-quic-echo-test.ps1
+++ b/.github/scripts/run-quic-echo-test.ps1
@@ -121,6 +121,8 @@ if ($ReceiverOptions -notmatch '--duration') {
   $ReceiverOptions += " --duration $serverDuration"
 }
 
+Write-ClientConcurrencySummary -Options $SenderOptions
+
 $ErrorActionPreference = 'Stop'
 $Session = $null
 $exitCode = 0
@@ -157,6 +159,36 @@ function Get-ReceiverBackend {
   }
 
   return 'msquic'
+}
+
+function Get-OptionValue {
+  param(
+    [Parameter(Mandatory=$true)][string]$Options,
+    [Parameter(Mandatory=$true)][string]$Name,
+    [Parameter(Mandatory=$true)][string]$DefaultValue
+  )
+
+  $tokens = Normalize-Args -Tokens (Convert-ArgStringToArray $Options)
+  for ($i = 0; $i -lt $tokens.Count; $i++) {
+    if ($tokens[$i] -eq $Name -and ($i + 1) -lt $tokens.Count) {
+      return $tokens[$i + 1]
+    }
+  }
+
+  return $DefaultValue
+}
+
+function Write-ClientConcurrencySummary {
+  param([Parameter(Mandatory=$true)][string]$Options)
+
+  $connections = [int](Get-OptionValue -Options $Options -Name '--connections' -DefaultValue '1')
+  $outstanding = [int](Get-OptionValue -Options $Options -Name '--outstanding' -DefaultValue '1')
+  $payload = [int](Get-OptionValue -Options $Options -Name '--payload' -DefaultValue '64')
+  $warmup = [int](Get-OptionValue -Options $Options -Name '--warmup' -DefaultValue '5')
+  $connectStaggerMs = [int](Get-OptionValue -Options $Options -Name '--connect-stagger-ms' -DefaultValue '25')
+  $maxInflight = $connections * $outstanding
+
+  Write-Phase "Client concurrency target: $connections connection(s), $outstanding outstanding request(s) per connection, $maxInflight max in-flight requests, payload ${payload}B, warmup ${warmup}s, connect stagger ${connectStaggerMs}ms"
 }
 
 function Get-QuicEchoKmDriverPath {

--- a/.github/scripts/run-quic-echo-test.ps1
+++ b/.github/scripts/run-quic-echo-test.ps1
@@ -305,6 +305,20 @@ function Ensure-MsQuicLoaded {
   }
 }
 
+function Get-WinQuicEchoServiceNames {
+  $serviceNames = @(
+    Get-Service -Name 'WinQuicEcho*' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
+  )
+
+  foreach ($name in @('WinQuicEcho', 'WinQuicEchoAlt')) {
+    if ($name -notin $serviceNames) {
+      $serviceNames += $name
+    }
+  }
+
+  return $serviceNames | Sort-Object -Unique
+}
+
 function Install-LocalWinQuicEchoKmDriver {
   param([Parameter(Mandatory=$true)][string]$DriverSourcePath)
 
@@ -317,8 +331,8 @@ function Install-LocalWinQuicEchoKmDriver {
   # Ensure msquic.sys is loaded (WinQuicEcho has PE import dependency on it)
   Ensure-MsQuicLoaded -Label 'local'
 
-  # Stop any running instance (primary or alternate service name).
-  foreach ($name in @('WinQuicEcho', 'WinQuicEchoAlt')) {
+  # Stop any running WinQuicEcho instance, including prior fallback names.
+  foreach ($name in Get-WinQuicEchoServiceNames) {
     $s = Get-Service -Name $name -ErrorAction SilentlyContinue
     if ($null -ne $s -and $s.Status -eq 'Running') {
       Write-Phase "Stopping existing local $name service"
@@ -411,8 +425,9 @@ function Install-RemoteWinQuicEchoKmDriver {
   Write-Phase "Copying WinQuicEcho kernel driver to remote path $remoteDriverSourcePath"
   Copy-Item -ToSession $Session -LiteralPath $DriverSourcePath -Destination $remoteDriverSourcePath -Force
 
-  Invoke-Command -Session $Session -ArgumentList $remoteDriverSourcePath -ScriptBlock {
-    param($driverSourcePath)
+  $remoteWinQuicEchoServiceNames = Get-WinQuicEchoServiceNames
+  Invoke-Command -Session $Session -ArgumentList $remoteDriverSourcePath, $remoteWinQuicEchoServiceNames -ScriptBlock {
+    param($driverSourcePath, $existingServiceNames)
 
     function Ensure-RemoteMsQuicLoaded {
       param([Parameter(Mandatory=$true)][string]$MsQuicPath)
@@ -471,9 +486,15 @@ function Install-RemoteWinQuicEchoKmDriver {
     $msquicSys = Join-Path $env:SystemRoot 'System32\drivers\msquic.sys'
     Ensure-RemoteMsQuicLoaded -MsQuicPath $msquicSys
 
-    # Stop any running instance (primary or alternate service name).
+    # Stop any running WinQuicEcho instance, including prior fallback names.
     # Verify the stop succeeded before proceeding.
-    foreach ($name in @('WinQuicEcho', 'WinQuicEchoAlt')) {
+    $serviceNames = @($existingServiceNames)
+    foreach ($service in Get-Service -Name 'WinQuicEcho*' -ErrorAction SilentlyContinue) {
+      if ($service.Name -notin $serviceNames) {
+        $serviceNames += $service.Name
+      }
+    }
+    foreach ($name in ($serviceNames | Sort-Object -Unique)) {
       $s = Get-Service -Name $name -ErrorAction SilentlyContinue
       if ($null -ne $s -and $s.Status -eq 'Running') {
         Write-Host "Stopping existing remote $name service"

--- a/.github/scripts/run-quic-echo-test.ps1
+++ b/.github/scripts/run-quic-echo-test.ps1
@@ -258,16 +258,17 @@ function Ensure-MsQuicLoaded {
   param([string]$Label = 'local')
 
   $msquicSys = Join-Path $env:SystemRoot 'System32\drivers\msquic.sys'
+  $relativeMsQuicPath = 'system32\drivers\msquic.sys'
   $WriteFunc = if ($Label -eq 'local') { { param($m) Write-Phase $m } } else { { param($m) Write-Host $m } }
 
   # Check if msquic.sys file exists
   if (-not (Test-Path -LiteralPath $msquicSys)) {
-    & $WriteFunc "WARNING: msquic.sys not found at $msquicSys"
+    & $WriteFunc "Required msquic.sys not found at $msquicSys"
     # Try to find it elsewhere on the system
     $found = Get-ChildItem -Path "$env:SystemRoot\System32\drivers" -Filter 'msquic*' -ErrorAction SilentlyContinue
     if ($found) { & $WriteFunc "Found msquic files: $($found.Name -join ', ')" }
     else { & $WriteFunc "No msquic driver files found in drivers directory" }
-    return
+    throw "Required msquic.sys was not found; kernel-mode WinQuicEcho tests require the inbox msquic driver."
   }
 
   & $WriteFunc "Found msquic.sys at $msquicSys (size: $((Get-Item $msquicSys).Length) bytes)"
@@ -277,15 +278,29 @@ function Ensure-MsQuicLoaded {
   if ($null -eq $svc) {
     & $WriteFunc "Creating msquic kernel service"
     & sc.exe create msquic type= kernel binPath= $msquicSys start= demand | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+      throw "sc create msquic failed with exit code $LASTEXITCODE"
+    }
+  }
+
+  try {
+    Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\msquic" -Name "ImagePath" -Value $relativeMsQuicPath
+  } catch {
+    throw "Failed to normalize msquic ImagePath: $($_.Exception.Message)"
   }
 
   # Start if not running
   $svc = Get-Service -Name 'msquic' -ErrorAction SilentlyContinue
-  if ($null -ne $svc -and $svc.Status -ne 'Running') {
+  if ($null -eq $svc) {
+    throw "msquic service was not found after create"
+  }
+  if ($svc.Status -ne 'Running') {
     & $WriteFunc "Starting msquic service"
     & sc.exe start msquic 2>&1
-    if ($LASTEXITCODE -ne 0) { & $WriteFunc "WARNING: msquic start failed with exit code $LASTEXITCODE" }
-  } elseif ($null -ne $svc) {
+    if ($LASTEXITCODE -ne 0) {
+      throw "sc start msquic failed with exit code $LASTEXITCODE"
+    }
+  } else {
     & $WriteFunc "msquic service is already running"
   }
 }
@@ -337,14 +352,14 @@ function Install-LocalWinQuicEchoKmDriver {
     $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
     if ($null -eq $svc) {
       Write-Phase "Creating local $name kernel service"
-      & sc.exe create $name type= kernel binPath= $driverDest start= demand | Out-Null
+      & sc.exe create $name type= kernel binPath= $driverDest start= demand depend= msquic | Out-Null
       if ($LASTEXITCODE -eq 0) {
         Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$name" -Name "ImagePath" -Value $relativeDriverPath
         $serviceName = $name; break
       }
       Write-Phase "sc create $name failed ($LASTEXITCODE); trying next name"
     } else {
-      & sc.exe config $name start= demand depend= / | Out-Null
+      & sc.exe config $name start= demand depend= msquic | Out-Null
       if ($LASTEXITCODE -eq 0) {
         Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$name" -Name "ImagePath" -Value $relativeDriverPath
         $serviceName = $name; Write-Phase "Reconfigured local $name service"; break
@@ -355,7 +370,7 @@ function Install-LocalWinQuicEchoKmDriver {
   if ($null -eq $serviceName) {
     $uniqueName = "WinQuicEcho_$([guid]::NewGuid().ToString('N').Substring(0,8))"
     Write-Phase "All primary service names exhausted; creating $uniqueName"
-    & sc.exe create $uniqueName type= kernel binPath= $driverDest start= demand | Out-Null
+    & sc.exe create $uniqueName type= kernel binPath= $driverDest start= demand depend= msquic | Out-Null
     if ($LASTEXITCODE -eq 0) {
       Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$uniqueName" -Name "ImagePath" -Value $relativeDriverPath
       $serviceName = $uniqueName
@@ -399,6 +414,51 @@ function Install-RemoteWinQuicEchoKmDriver {
   Invoke-Command -Session $Session -ArgumentList $remoteDriverSourcePath -ScriptBlock {
     param($driverSourcePath)
 
+    function Ensure-RemoteMsQuicLoaded {
+      param([Parameter(Mandatory=$true)][string]$MsQuicPath)
+
+      $relativeMsQuicPath = 'system32\drivers\msquic.sys'
+
+      if (-not (Test-Path -LiteralPath $MsQuicPath)) {
+        Write-Host "Required msquic.sys not found at $MsQuicPath"
+        $found = Get-ChildItem -Path "$env:SystemRoot\System32\drivers" -Filter 'msquic*' -ErrorAction SilentlyContinue
+        if ($found) { Write-Host "Found msquic files: $($found.Name -join ', ')" }
+        else { Write-Host "No msquic driver files found in drivers directory" }
+        throw "Required msquic.sys was not found; kernel-mode WinQuicEcho tests require the inbox msquic driver."
+      }
+
+      Write-Host "Found msquic.sys at $MsQuicPath (size: $((Get-Item $MsQuicPath).Length) bytes)"
+
+      $svc = Get-Service -Name 'msquic' -ErrorAction SilentlyContinue
+      if ($null -eq $svc) {
+        Write-Host "Creating msquic kernel service"
+        & sc.exe create msquic type= kernel binPath= $MsQuicPath start= demand | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+          throw "Remote sc create msquic failed with exit code $LASTEXITCODE"
+        }
+      }
+
+      try {
+        Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\msquic" -Name "ImagePath" -Value $relativeMsQuicPath
+      } catch {
+        throw "Failed to normalize remote msquic ImagePath: $($_.Exception.Message)"
+      }
+
+      $svc = Get-Service -Name 'msquic' -ErrorAction SilentlyContinue
+      if ($null -eq $svc) {
+        throw "Remote msquic service was not found after create"
+      }
+      if ($svc.Status -ne 'Running') {
+        Write-Host "Starting msquic service"
+        & sc.exe start msquic 2>&1 | ForEach-Object { Write-Host "  $_" }
+        if ($LASTEXITCODE -ne 0) {
+          throw "Remote sc start msquic failed with exit code $LASTEXITCODE"
+        }
+      } else {
+        Write-Host "msquic service is already running"
+      }
+    }
+
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
     $principal = [Security.Principal.WindowsPrincipal]::new($identity)
     if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
@@ -409,23 +469,7 @@ function Install-RemoteWinQuicEchoKmDriver {
 
     # Ensure msquic.sys is loaded (WinQuicEcho has PE import dependency on it)
     $msquicSys = Join-Path $env:SystemRoot 'System32\drivers\msquic.sys'
-    if (Test-Path -LiteralPath $msquicSys) {
-      Write-Host "Found msquic.sys at $msquicSys (size: $((Get-Item $msquicSys).Length) bytes)"
-      $svc = Get-Service -Name 'msquic' -ErrorAction SilentlyContinue
-      if ($null -eq $svc) {
-        Write-Host "Creating msquic kernel service"
-        & sc.exe create msquic type= kernel binPath= $msquicSys start= demand | Out-Null
-      }
-      $svc = Get-Service -Name 'msquic' -ErrorAction SilentlyContinue
-      if ($null -ne $svc -and $svc.Status -ne 'Running') {
-        Write-Host "Starting msquic service"
-        & sc.exe start msquic 2>&1
-      } elseif ($null -ne $svc) { Write-Host "msquic service is already running" }
-    } else {
-      Write-Host "WARNING: msquic.sys not found at $msquicSys"
-      $found = Get-ChildItem -Path "$env:SystemRoot\System32\drivers" -Filter 'msquic*' -ErrorAction SilentlyContinue
-      if ($found) { Write-Host "Found msquic files: $($found.Name -join ', ')" }
-    }
+    Ensure-RemoteMsQuicLoaded -MsQuicPath $msquicSys
 
     # Stop any running instance (primary or alternate service name).
     # Verify the stop succeeded before proceeding.
@@ -442,7 +486,7 @@ function Install-RemoteWinQuicEchoKmDriver {
         }
         $s = Get-Service -Name $name -ErrorAction SilentlyContinue
         if ($null -ne $s -and $s.Status -eq 'Running') {
-          Write-Host "WARNING: Remote $name service still running after stop attempt"
+          throw "Remote $name service is still running after stop attempt"
         }
       }
     }
@@ -470,14 +514,14 @@ function Install-RemoteWinQuicEchoKmDriver {
       $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
       if ($null -eq $svc) {
         Write-Host "Creating remote $name kernel service"
-        & sc.exe create $name type= kernel binPath= $driverDest start= demand | Out-Null
+        & sc.exe create $name type= kernel binPath= $driverDest start= demand depend= msquic | Out-Null
         if ($LASTEXITCODE -eq 0) {
           Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$name" -Name "ImagePath" -Value $relativeDriverPath
           $serviceName = $name; break
         }
         Write-Host "sc create $name failed ($LASTEXITCODE); trying next name"
       } else {
-        & sc.exe config $name start= demand depend= / | Out-Null
+        & sc.exe config $name start= demand depend= msquic | Out-Null
         if ($LASTEXITCODE -eq 0) {
           Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$name" -Name "ImagePath" -Value $relativeDriverPath
           $serviceName = $name; Write-Host "Reconfigured remote $name service"; break
@@ -488,7 +532,7 @@ function Install-RemoteWinQuicEchoKmDriver {
     if ($null -eq $serviceName) {
       $uniqueName = "WinQuicEcho_$([guid]::NewGuid().ToString('N').Substring(0,8))"
       Write-Host "All primary service names exhausted; creating $uniqueName"
-      & sc.exe create $uniqueName type= kernel binPath= $driverDest start= demand | Out-Null
+      & sc.exe create $uniqueName type= kernel binPath= $driverDest start= demand depend= msquic | Out-Null
       if ($LASTEXITCODE -eq 0) {
         Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$uniqueName" -Name "ImagePath" -Value $relativeDriverPath
         $serviceName = $uniqueName

--- a/.github/scripts/run-quic-echo-test.ps1
+++ b/.github/scripts/run-quic-echo-test.ps1
@@ -254,6 +254,42 @@ function Prepare-WinQuicEchoKmDriver {
   } -ErrorAction Stop
 }
 
+function Ensure-MsQuicLoaded {
+  param([string]$Label = 'local')
+
+  $msquicSys = Join-Path $env:SystemRoot 'System32\drivers\msquic.sys'
+  $WriteFunc = if ($Label -eq 'local') { { param($m) Write-Phase $m } } else { { param($m) Write-Host $m } }
+
+  # Check if msquic.sys file exists
+  if (-not (Test-Path -LiteralPath $msquicSys)) {
+    & $WriteFunc "WARNING: msquic.sys not found at $msquicSys"
+    # Try to find it elsewhere on the system
+    $found = Get-ChildItem -Path "$env:SystemRoot\System32\drivers" -Filter 'msquic*' -ErrorAction SilentlyContinue
+    if ($found) { & $WriteFunc "Found msquic files: $($found.Name -join ', ')" }
+    else { & $WriteFunc "No msquic driver files found in drivers directory" }
+    return
+  }
+
+  & $WriteFunc "Found msquic.sys at $msquicSys (size: $((Get-Item $msquicSys).Length) bytes)"
+
+  # Ensure service entry exists
+  $svc = Get-Service -Name 'msquic' -ErrorAction SilentlyContinue
+  if ($null -eq $svc) {
+    & $WriteFunc "Creating msquic kernel service"
+    & sc.exe create msquic type= kernel binPath= $msquicSys start= demand | Out-Null
+  }
+
+  # Start if not running
+  $svc = Get-Service -Name 'msquic' -ErrorAction SilentlyContinue
+  if ($null -ne $svc -and $svc.Status -ne 'Running') {
+    & $WriteFunc "Starting msquic service"
+    & sc.exe start msquic 2>&1
+    if ($LASTEXITCODE -ne 0) { & $WriteFunc "WARNING: msquic start failed with exit code $LASTEXITCODE" }
+  } elseif ($null -ne $svc) {
+    & $WriteFunc "msquic service is already running"
+  }
+}
+
 function Install-LocalWinQuicEchoKmDriver {
   param([Parameter(Mandatory=$true)][string]$DriverSourcePath)
 
@@ -261,34 +297,82 @@ function Install-LocalWinQuicEchoKmDriver {
     throw "Installing the WinQuicEcho kernel driver locally requires administrator privileges."
   }
 
-  $serviceName = 'WinQuicEcho'
   $driverDest = Join-Path $env:SystemRoot 'System32\drivers\winquicecho_km.sys'
 
-  $svc = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
-  if ($null -ne $svc) {
-    if ($svc.Status -eq 'Running') {
-      Write-Phase "Stopping existing local $serviceName service"
-      & sc.exe stop $serviceName | Out-Null
+  # Ensure msquic.sys is loaded (WinQuicEcho has PE import dependency on it)
+  Ensure-MsQuicLoaded -Label 'local'
+
+  # Stop any running instance (primary or alternate service name).
+  foreach ($name in @('WinQuicEcho', 'WinQuicEchoAlt')) {
+    $s = Get-Service -Name $name -ErrorAction SilentlyContinue
+    if ($null -ne $s -and $s.Status -eq 'Running') {
+      Write-Phase "Stopping existing local $name service"
+      & sc.exe stop $name | Out-Null
       Start-Sleep -Seconds 2
     }
-    Write-Phase "Deleting existing local $serviceName service"
-    & sc.exe delete $serviceName | Out-Null
-    Start-Sleep -Seconds 2
+  }
+
+  # Kernel driver images stay memory-mapped (file-locked) even after unload.
+  # Rename the stale file out of the way so we can place the new one.
+  if (Test-Path -LiteralPath $driverDest) {
+    $stale = "${driverDest}.$([guid]::NewGuid().ToString('N')).old"
+    try {
+      Move-Item -LiteralPath $driverDest -Destination $stale -Force
+      Write-Phase "Renamed stale driver to $stale"
+    } catch {
+      Write-Phase "Could not rename stale driver ($($_.Exception.Message)); will overwrite in place"
+    }
   }
 
   Write-Phase "Copying local WinQuicEcho driver to $driverDest"
   Copy-Item -LiteralPath $DriverSourcePath -Destination $driverDest -Force
 
-  Write-Phase "Creating local $serviceName kernel service"
-  & sc.exe create $serviceName type= kernel binPath= $driverDest start= demand depend= msquic | Out-Null
-  if ($LASTEXITCODE -ne 0) {
-    throw "Local sc create failed with exit code $LASTEXITCODE"
+  # Pick a usable service name. A prior sc.exe delete can leave a zombie
+  # entry that blocks create (1072) and config (1072). The driver's device
+  # name is hardcoded so ANY service name works.
+  # Use relative ImagePath (like msquic) — the I/O Manager prepends \SystemRoot\.
+  $serviceName = $null
+  $relativeDriverPath = "system32\drivers\winquicecho_km.sys"
+  foreach ($name in @('WinQuicEcho', 'WinQuicEchoAlt')) {
+    $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+    if ($null -eq $svc) {
+      Write-Phase "Creating local $name kernel service"
+      & sc.exe create $name type= kernel binPath= $driverDest start= demand | Out-Null
+      if ($LASTEXITCODE -eq 0) {
+        Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$name" -Name "ImagePath" -Value $relativeDriverPath
+        $serviceName = $name; break
+      }
+      Write-Phase "sc create $name failed ($LASTEXITCODE); trying next name"
+    } else {
+      & sc.exe config $name start= demand depend= / | Out-Null
+      if ($LASTEXITCODE -eq 0) {
+        Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$name" -Name "ImagePath" -Value $relativeDriverPath
+        $serviceName = $name; Write-Phase "Reconfigured local $name service"; break
+      }
+      Write-Phase "sc config $name failed ($LASTEXITCODE); trying next name"
+    }
+  }
+  if ($null -eq $serviceName) {
+    $uniqueName = "WinQuicEcho_$([guid]::NewGuid().ToString('N').Substring(0,8))"
+    Write-Phase "All primary service names exhausted; creating $uniqueName"
+    & sc.exe create $uniqueName type= kernel binPath= $driverDest start= demand | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+      Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$uniqueName" -Name "ImagePath" -Value $relativeDriverPath
+      $serviceName = $uniqueName
+    }
+    else { throw "Cannot create service $uniqueName (exit=$LASTEXITCODE). The VM may need a reboot." }
+  }
+
+  if (-not (Test-Path -LiteralPath $driverDest)) {
+    throw "Driver file not found at $driverDest after copy"
   }
 
   Write-Phase "Starting local $serviceName kernel service"
-  & sc.exe start $serviceName
-  if ($LASTEXITCODE -ne 0) {
-    throw "Local sc start failed with exit code $LASTEXITCODE"
+  try {
+    Start-Service -Name $serviceName -ErrorAction Stop
+    Write-Phase "Service $serviceName started successfully"
+  } catch {
+    throw "Local driver start failed: $($_.Exception.Message)"
   }
 }
 
@@ -321,33 +405,112 @@ function Install-RemoteWinQuicEchoKmDriver {
       throw "Installing the WinQuicEcho kernel driver remotely requires administrator privileges."
     }
 
-    $serviceName = 'WinQuicEcho'
     $driverDest = Join-Path $env:SystemRoot 'System32\drivers\winquicecho_km.sys'
-    $svc = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
-    if ($null -ne $svc) {
-      if ($svc.Status -eq 'Running') {
-        Write-Host "Stopping existing remote $serviceName service"
-        & sc.exe stop $serviceName | Out-Null
-        Start-Sleep -Seconds 2
+
+    # Ensure msquic.sys is loaded (WinQuicEcho has PE import dependency on it)
+    $msquicSys = Join-Path $env:SystemRoot 'System32\drivers\msquic.sys'
+    if (Test-Path -LiteralPath $msquicSys) {
+      Write-Host "Found msquic.sys at $msquicSys (size: $((Get-Item $msquicSys).Length) bytes)"
+      $svc = Get-Service -Name 'msquic' -ErrorAction SilentlyContinue
+      if ($null -eq $svc) {
+        Write-Host "Creating msquic kernel service"
+        & sc.exe create msquic type= kernel binPath= $msquicSys start= demand | Out-Null
       }
-      Write-Host "Deleting existing remote $serviceName service"
-      & sc.exe delete $serviceName | Out-Null
-      Start-Sleep -Seconds 2
+      $svc = Get-Service -Name 'msquic' -ErrorAction SilentlyContinue
+      if ($null -ne $svc -and $svc.Status -ne 'Running') {
+        Write-Host "Starting msquic service"
+        & sc.exe start msquic 2>&1
+      } elseif ($null -ne $svc) { Write-Host "msquic service is already running" }
+    } else {
+      Write-Host "WARNING: msquic.sys not found at $msquicSys"
+      $found = Get-ChildItem -Path "$env:SystemRoot\System32\drivers" -Filter 'msquic*' -ErrorAction SilentlyContinue
+      if ($found) { Write-Host "Found msquic files: $($found.Name -join ', ')" }
+    }
+
+    # Stop any running instance (primary or alternate service name).
+    # Verify the stop succeeded before proceeding.
+    foreach ($name in @('WinQuicEcho', 'WinQuicEchoAlt')) {
+      $s = Get-Service -Name $name -ErrorAction SilentlyContinue
+      if ($null -ne $s -and $s.Status -eq 'Running') {
+        Write-Host "Stopping existing remote $name service"
+        & sc.exe stop $name 2>&1 | ForEach-Object { Write-Host "  $_" }
+        # Wait for service to fully stop
+        for ($i = 0; $i -lt 15; $i++) {
+          $s = Get-Service -Name $name -ErrorAction SilentlyContinue
+          if ($null -eq $s -or $s.Status -ne 'Running') { break }
+          Start-Sleep -Seconds 1
+        }
+        $s = Get-Service -Name $name -ErrorAction SilentlyContinue
+        if ($null -ne $s -and $s.Status -eq 'Running') {
+          Write-Host "WARNING: Remote $name service still running after stop attempt"
+        }
+      }
+    }
+
+    # Kernel driver images stay memory-mapped (file-locked) even after unload.
+    if (Test-Path -LiteralPath $driverDest) {
+      $stale = "${driverDest}.$([guid]::NewGuid().ToString('N')).old"
+      try {
+        Move-Item -LiteralPath $driverDest -Destination $stale -Force
+        Write-Host "Renamed stale driver to $stale"
+      } catch {
+        Write-Host "Could not rename stale driver ($($_.Exception.Message)); will overwrite in place"
+      }
     }
 
     Write-Host "Copying remote WinQuicEcho driver to $driverDest"
     Copy-Item -LiteralPath $driverSourcePath -Destination $driverDest -Force
 
-    Write-Host "Creating remote $serviceName kernel service"
-    & sc.exe create $serviceName type= kernel binPath= $driverDest start= demand depend= msquic | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-      throw "Remote sc create failed with exit code $LASTEXITCODE"
+    # Pick a usable service name, falling back to an alternate if the
+    # primary is a zombie from a prior sc.exe delete.
+    # Use relative ImagePath (like msquic) for reliable kernel driver loading.
+    $relativeDriverPath = "system32\drivers\winquicecho_km.sys"
+    $serviceName = $null
+    foreach ($name in @('WinQuicEcho', 'WinQuicEchoAlt')) {
+      $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+      if ($null -eq $svc) {
+        Write-Host "Creating remote $name kernel service"
+        & sc.exe create $name type= kernel binPath= $driverDest start= demand | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+          Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$name" -Name "ImagePath" -Value $relativeDriverPath
+          $serviceName = $name; break
+        }
+        Write-Host "sc create $name failed ($LASTEXITCODE); trying next name"
+      } else {
+        & sc.exe config $name start= demand depend= / | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+          Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$name" -Name "ImagePath" -Value $relativeDriverPath
+          $serviceName = $name; Write-Host "Reconfigured remote $name service"; break
+        }
+        Write-Host "sc config $name failed ($LASTEXITCODE); trying next name"
+      }
+    }
+    if ($null -eq $serviceName) {
+      $uniqueName = "WinQuicEcho_$([guid]::NewGuid().ToString('N').Substring(0,8))"
+      Write-Host "All primary service names exhausted; creating $uniqueName"
+      & sc.exe create $uniqueName type= kernel binPath= $driverDest start= demand | Out-Null
+      if ($LASTEXITCODE -eq 0) {
+        Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Services\$uniqueName" -Name "ImagePath" -Value $relativeDriverPath
+        $serviceName = $uniqueName
+      } else { throw "Cannot create service $uniqueName (exit=$LASTEXITCODE). The VM may need a reboot." }
+    }
+
+    if (-not (Test-Path -LiteralPath $driverDest)) {
+      throw "Driver file not found at $driverDest after copy"
     }
 
     Write-Host "Starting remote $serviceName kernel service"
-    & sc.exe start $serviceName
-    if ($LASTEXITCODE -ne 0) {
-      throw "Remote sc start failed with exit code $LASTEXITCODE"
+    $svcStatus = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+    if ($null -ne $svcStatus -and $svcStatus.Status -eq 'Running') {
+      Write-Host "Service $serviceName is already running"
+    } else {
+      try {
+        Start-Service -Name $serviceName -ErrorAction Stop
+        Write-Host "Service $serviceName started successfully"
+      } catch {
+        & sc.exe start $serviceName 2>&1 | ForEach-Object { Write-Host "  sc.exe: $_" }
+        throw "Remote service start failed: $($_.Exception.Message)"
+      }
     }
   } -ErrorAction Stop
 }
@@ -748,9 +911,18 @@ function Run-RecvTest {
     Write-Phase "Waiting 5s for local echo_server to initialize..."
     Start-Sleep -Seconds 5
 
-    # Client runs on remote
+    # Client runs on remote — replace --server with the local machine's hostname
+    # so the remote client connects back to us, not to itself.
     $clientArgs = Convert-ArgStringToArray $SenderOptions
     $clientArgs = Normalize-Args -Tokens $clientArgs
+    $localHostname = $env:COMPUTERNAME
+    for ($i = 0; $i -lt $clientArgs.Count; $i++) {
+      if ($clientArgs[$i] -eq '--server' -and ($i + 1) -lt $clientArgs.Count) {
+        Write-Host "[Recv] Replacing --server '$($clientArgs[$i+1])' with local hostname '$localHostname'"
+        $clientArgs[$i+1] = $localHostname
+        break
+      }
+    }
     # No --verbose: it logs per-datagram events, throttling throughput via I/O backpressure
     Write-Host "[Local->Remote] Invoking remote echo_client with arguments:"
     if ($clientArgs -is [System.Array]) { foreach ($arg in $clientArgs) { Write-Host "  $arg" } } else { Write-Host "  $clientArgs" }

--- a/.github/scripts/run-quic-echo-test.ps1
+++ b/.github/scripts/run-quic-echo-test.ps1
@@ -319,6 +319,59 @@ function Get-WinQuicEchoServiceNames {
   return $serviceNames | Sort-Object -Unique
 }
 
+function Remove-OldWinQuicEchoDriverBackups {
+  param(
+    [Parameter(Mandatory=$true)][string]$DriverPath,
+    [int]$KeepCount = 3
+  )
+
+  $backupPattern = '{0}.*.old' -f [IO.Path]::GetFileName($DriverPath)
+  $backupDir = Split-Path -Parent $DriverPath
+  if (-not (Test-Path -LiteralPath $backupDir)) {
+    return
+  }
+
+  $backups = @(Get-ChildItem -LiteralPath $backupDir -Filter $backupPattern -File -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending)
+  if ($backups.Count -le $KeepCount) {
+    return
+  }
+
+  foreach ($backup in $backups | Select-Object -Skip $KeepCount) {
+    try {
+      Remove-Item -LiteralPath $backup.FullName -Force
+      Write-Phase "Removed stale driver backup $($backup.FullName)"
+    } catch {
+      Write-Phase "Could not remove stale driver backup $($backup.FullName): $($_.Exception.Message)"
+    }
+  }
+}
+
+function Update-ServerArgument {
+  param(
+    [Parameter(Mandatory=$true)][string[]]$Args,
+    [Parameter(Mandatory=$true)][string]$ServerName,
+    [string]$LogPrefix = '[Recv]'
+  )
+
+  for ($i = 0; $i -lt $Args.Count; $i++) {
+    if ($Args[$i] -eq '--server' -and ($i + 1) -lt $Args.Count) {
+      Write-Host "$LogPrefix Replacing --server '$($Args[$i+1])' with local hostname '$ServerName'"
+      $Args[$i+1] = $ServerName
+      break
+    }
+
+    if ($Args[$i] -like '--server=*') {
+      $existingServer = $Args[$i].Substring('--server='.Length)
+      Write-Host "$LogPrefix Replacing --server '$existingServer' with local hostname '$ServerName'"
+      $Args[$i] = "--server=$ServerName"
+      break
+    }
+  }
+
+  return $Args
+}
+
 function Install-LocalWinQuicEchoKmDriver {
   param([Parameter(Mandatory=$true)][string]$DriverSourcePath)
 
@@ -352,6 +405,7 @@ function Install-LocalWinQuicEchoKmDriver {
       Write-Phase "Could not rename stale driver ($($_.Exception.Message)); will overwrite in place"
     }
   }
+  Remove-OldWinQuicEchoDriverBackups -DriverPath $driverDest
 
   Write-Phase "Copying local WinQuicEcho driver to $driverDest"
   Copy-Item -LiteralPath $DriverSourcePath -Destination $driverDest -Force
@@ -520,6 +574,17 @@ function Install-RemoteWinQuicEchoKmDriver {
         Write-Host "Renamed stale driver to $stale"
       } catch {
         Write-Host "Could not rename stale driver ($($_.Exception.Message)); will overwrite in place"
+      }
+    }
+    $backupPattern = '{0}.*.old' -f [IO.Path]::GetFileName($driverDest)
+    $backups = @(Get-ChildItem -LiteralPath (Split-Path -Parent $driverDest) -Filter $backupPattern -File -ErrorAction SilentlyContinue |
+      Sort-Object LastWriteTime -Descending)
+    foreach ($backup in $backups | Select-Object -Skip 3) {
+      try {
+        Remove-Item -LiteralPath $backup.FullName -Force
+        Write-Host "Removed stale remote driver backup $($backup.FullName)"
+      } catch {
+        Write-Host "Could not remove stale remote driver backup $($backup.FullName): $($_.Exception.Message)"
       }
     }
 
@@ -981,13 +1046,7 @@ function Run-RecvTest {
     $clientArgs = Convert-ArgStringToArray $SenderOptions
     $clientArgs = Normalize-Args -Tokens $clientArgs
     $localHostname = $env:COMPUTERNAME
-    for ($i = 0; $i -lt $clientArgs.Count; $i++) {
-      if ($clientArgs[$i] -eq '--server' -and ($i + 1) -lt $clientArgs.Count) {
-        Write-Host "[Recv] Replacing --server '$($clientArgs[$i+1])' with local hostname '$localHostname'"
-        $clientArgs[$i+1] = $localHostname
-        break
-      }
-    }
+    $clientArgs = Update-ServerArgument -Args $clientArgs -ServerName $localHostname
     # No --verbose: it logs per-datagram events, throttling throughput via I/O backpressure
     Write-Host "[Local->Remote] Invoking remote echo_client with arguments:"
     if ($clientArgs -is [System.Array]) { foreach ($arg in $clientArgs) { Write-Host "  $arg" } } else { Write-Host "  $clientArgs" }

--- a/.github/scripts/run-quic-echo-test.ps1
+++ b/.github/scripts/run-quic-echo-test.ps1
@@ -134,6 +134,7 @@ $script:localCertStoreLocation = 'CurrentUser'
 $script:remoteCertStoreLocation = 'CurrentUser'
 $script:driverCodeSigningThumbprint = $null
 $script:driverCodeSigningCerPath = $null
+$script:usesPemCerts = $false
 
 function Write-Phase {
   param([Parameter(Mandatory=$true)][string]$Message)
@@ -593,7 +594,7 @@ function Install-RemoteWinQuicEchoKmDriver {
         }
         $s = Get-Service -Name $name -ErrorAction SilentlyContinue
         if ($null -ne $s -and $s.Status -eq 'Running') {
-          throw "Remote $name service is still running after stop attempt"
+          Write-Warning "Remote $name service is still running after stop attempt"
         }
       }
     }

--- a/.github/scripts/run-quic-echo-test.ps1
+++ b/.github/scripts/run-quic-echo-test.ps1
@@ -121,8 +121,6 @@ if ($ReceiverOptions -notmatch '--duration') {
   $ReceiverOptions += " --duration $serverDuration"
 }
 
-Write-ClientConcurrencySummary -Options $SenderOptions
-
 $ErrorActionPreference = 'Stop'
 $Session = $null
 $exitCode = 0
@@ -190,6 +188,8 @@ function Write-ClientConcurrencySummary {
 
   Write-Phase "Client concurrency target: $connections connection(s), $outstanding outstanding request(s) per connection, $maxInflight max in-flight requests, payload ${payload}B, warmup ${warmup}s, connect stagger ${connectStaggerMs}ms"
 }
+
+Write-ClientConcurrencySummary -Options $SenderOptions
 
 function Get-QuicEchoKmDriverPath {
   $toolRoot = Split-Path -Parent $scriptDir

--- a/.github/workflows/network-traffic-performance.yml
+++ b/.github/workflows/network-traffic-performance.yml
@@ -431,7 +431,7 @@ jobs:
       ref: '53cd6c01279eb789f6b52218121c248088a0d608'
 
   test_quic_echo:
-    if: ${{ inputs.test_tool == 'quicEcho' }}
+    if: ${{ inputs.test_tool == 'quicEcho' && (!contains(inputs.receiver_options, '--backend msquic-km') || matrix.vec.supports_msquic_km) }}
     name: Network Traffic Test (QUIC echo)
     needs: [build_quic_echo]
     strategy:
@@ -443,6 +443,7 @@ jobs:
             arch: x64
             # Extra runner label to narrow the runner pool for this environment.
             runner_extra: ebpf
+            supports_msquic_km: false
             sender_connections: ''
             sender_outstanding: ''
             sender_connect_stagger_ms: ''
@@ -452,6 +453,7 @@ jobs:
             arch: x64
             # No ebpf label on the rs_iof runner; use harmless duplicate.
             runner_extra: self-hosted
+            supports_msquic_km: true
             # Match the current RSS fanout on the rs_iof VMs and allow enough
             # in-flight work to expose bottlenecks beyond single-RTT ping-pong.
             sender_connections: '16'

--- a/.github/workflows/network-traffic-performance.yml
+++ b/.github/workflows/network-traffic-performance.yml
@@ -443,11 +443,21 @@ jobs:
             arch: x64
             # Extra runner label to narrow the runner pool for this environment.
             runner_extra: ebpf
+            sender_connections: ''
+            sender_outstanding: ''
+            sender_connect_stagger_ms: ''
+            sender_warmup: ''
           - env: lab
             os: "rsiof"
             arch: x64
             # No ebpf label on the rs_iof runner; use harmless duplicate.
             runner_extra: self-hosted
+            # Match the current RSS fanout on the rs_iof VMs and allow enough
+            # in-flight work to expose bottlenecks beyond single-RTT ping-pong.
+            sender_connections: '16'
+            sender_outstanding: '16'
+            sender_connect_stagger_ms: '0'
+            sender_warmup: '15'
     runs-on:
       - self-hosted
       - ${{ matrix.vec.env }}
@@ -531,6 +541,10 @@ jobs:
         Write-Output "Input parameters:"
         Write-Output "  Profile: ${{ inputs.profile }}"
         Write-Output "  SenderOptions: ${{ inputs.sender_options }}"
+        Write-Output "  Matrix SenderConnections: ${{ matrix.vec.sender_connections }}"
+        Write-Output "  Matrix SenderOutstanding: ${{ matrix.vec.sender_outstanding }}"
+        Write-Output "  Matrix SenderConnectStaggerMs: ${{ matrix.vec.sender_connect_stagger_ms }}"
+        Write-Output "  Matrix SenderWarmup: ${{ matrix.vec.sender_warmup }}"
         Write-Output "  ReceiverOptions: ${{ inputs.receiver_options }}"
         Write-Output "  TCP IP Tracing: ${{ inputs.tcp_ip_tracing }}"
         Write-Output "  ref: ${{ inputs.ref }}"
@@ -556,14 +570,41 @@ jobs:
       env:
         PROFILE: ${{ inputs.profile }}
         SENDER_OPTIONS: ${{ inputs.sender_options }}
+        MATRIX_SENDER_CONNECTIONS: ${{ matrix.vec.sender_connections }}
+        MATRIX_SENDER_OUTSTANDING: ${{ matrix.vec.sender_outstanding }}
+        MATRIX_SENDER_CONNECT_STAGGER_MS: ${{ matrix.vec.sender_connect_stagger_ms }}
+        MATRIX_SENDER_WARMUP: ${{ matrix.vec.sender_warmup }}
         RECEIVER_OPTIONS: ${{ inputs.receiver_options }}
       shell: pwsh
       run: |
         $scriptPath = '.\run-quic-echo-test.ps1'
+        function Add-DefaultCliOption {
+          param(
+            [Parameter(Mandatory = $true)][string]$Options,
+            [Parameter(Mandatory = $true)][string]$Name,
+            [string]$Value
+          )
+
+          if ([string]::IsNullOrWhiteSpace($Value)) {
+            return $Options
+          }
+
+          if ($Options -match "(^|\s)$([regex]::Escape($Name))(?=\s|$)") {
+            return $Options
+          }
+
+          return ("$Options $Name $Value").Trim()
+        }
+
+        $effectiveSenderOptions = $env:SENDER_OPTIONS
+        $effectiveSenderOptions = Add-DefaultCliOption -Options $effectiveSenderOptions -Name '--connections' -Value $env:MATRIX_SENDER_CONNECTIONS
+        $effectiveSenderOptions = Add-DefaultCliOption -Options $effectiveSenderOptions -Name '--outstanding' -Value $env:MATRIX_SENDER_OUTSTANDING
+        $effectiveSenderOptions = Add-DefaultCliOption -Options $effectiveSenderOptions -Name '--connect-stagger-ms' -Value $env:MATRIX_SENDER_CONNECT_STAGGER_MS
+        $effectiveSenderOptions = Add-DefaultCliOption -Options $effectiveSenderOptions -Name '--warmup' -Value $env:MATRIX_SENDER_WARMUP
 
         $params = @{
           PeerName = 'netperf-peer'
-          SenderOptions = $env:SENDER_OPTIONS
+          SenderOptions = $effectiveSenderOptions
           ReceiverOptions = $env:RECEIVER_OPTIONS
           Duration = '${{ inputs.duration }}'
         }

--- a/.github/workflows/network-traffic-performance.yml
+++ b/.github/workflows/network-traffic-performance.yml
@@ -441,12 +441,19 @@ jobs:
           - env: lab
             os: "2022"
             arch: x64
+            # Extra runner label to narrow the runner pool for this environment.
+            runner_extra: ebpf
+          - env: lab
+            os: "rsiof"
+            arch: x64
+            # No ebpf label on the rs_iof runner; use harmless duplicate.
+            runner_extra: self-hosted
     runs-on:
       - self-hosted
       - ${{ matrix.vec.env }}
       - os-windows-${{ matrix.vec.os }}
       - ${{ matrix.vec.arch }}
-      - ebpf
+      - ${{ matrix.vec.runner_extra }}
 
     steps:
     - name: Pre-clean leftover PktMon artifacts

--- a/.github/workflows/network-traffic-performance.yml
+++ b/.github/workflows/network-traffic-performance.yml
@@ -431,35 +431,15 @@ jobs:
       ref: '53cd6c01279eb789f6b52218121c248088a0d608'
 
   test_quic_echo:
-    if: ${{ inputs.test_tool == 'quicEcho' && (!contains(inputs.receiver_options, '--backend msquic-km') || matrix.vec.supports_msquic_km) }}
+    if: ${{ inputs.test_tool == 'quicEcho' }}
     name: Network Traffic Test (QUIC echo)
     needs: [build_quic_echo]
     strategy:
       fail-fast: false
       matrix:
-        vec:
-          - env: lab
-            os: "2022"
-            arch: x64
-            # Extra runner label to narrow the runner pool for this environment.
-            runner_extra: ebpf
-            supports_msquic_km: false
-            sender_connections: ''
-            sender_outstanding: ''
-            sender_connect_stagger_ms: ''
-            sender_warmup: ''
-          - env: lab
-            os: "rsiof"
-            arch: x64
-            # No ebpf label on the rs_iof runner; use harmless duplicate.
-            runner_extra: self-hosted
-            supports_msquic_km: true
-            # Match the current RSS fanout on the rs_iof VMs and allow enough
-            # in-flight work to expose bottlenecks beyond single-RTT ping-pong.
-            sender_connections: '16'
-            sender_outstanding: '16'
-            sender_connect_stagger_ms: '0'
-            sender_warmup: '15'
+        vec: ${{ fromJSON(contains(inputs.receiver_options, '--backend msquic-km') &&
+          '[{"env":"lab","os":"rsiof","arch":"x64","runner_extra":"self-hosted","sender_connections":"16","sender_outstanding":"16","sender_connect_stagger_ms":"0","sender_warmup":"15"}]' ||
+          '[{"env":"lab","os":"2022","arch":"x64","runner_extra":"ebpf","sender_connections":"","sender_outstanding":"","sender_connect_stagger_ms":"","sender_warmup":""},{"env":"lab","os":"rsiof","arch":"x64","runner_extra":"self-hosted","sender_connections":"16","sender_outstanding":"16","sender_connect_stagger_ms":"0","sender_warmup":"15"}]') }}
     runs-on:
       - self-hosted
       - ${{ matrix.vec.env }}

--- a/.github/workflows/network-traffic-performance.yml
+++ b/.github/workflows/network-traffic-performance.yml
@@ -47,6 +47,11 @@ on:
         required: false
         default: '60'
         type: string
+      request_response_size:
+        description: 'Payload size in bytes for both request and echoed response (QUIC echo only)'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -531,6 +536,7 @@ jobs:
         Write-Output "  TCP IP Tracing: ${{ inputs.tcp_ip_tracing }}"
         Write-Output "  ref: ${{ inputs.ref }}"
         Write-Output "  Duration: ${{ inputs.duration }}"
+        Write-Output "  RequestResponseSize: ${{ inputs.request_response_size }}"
 
     - name: Diagnostic - List files in quic_echo Release directory
       run: |
@@ -557,6 +563,7 @@ jobs:
         MATRIX_SENDER_CONNECT_STAGGER_MS: ${{ matrix.vec.sender_connect_stagger_ms }}
         MATRIX_SENDER_WARMUP: ${{ matrix.vec.sender_warmup }}
         RECEIVER_OPTIONS: ${{ inputs.receiver_options }}
+        REQUEST_RESPONSE_SIZE: ${{ inputs.request_response_size }}
       shell: pwsh
       run: |
         $scriptPath = '.\run-quic-echo-test.ps1'
@@ -583,6 +590,7 @@ jobs:
         $effectiveSenderOptions = Add-DefaultCliOption -Options $effectiveSenderOptions -Name '--outstanding' -Value $env:MATRIX_SENDER_OUTSTANDING
         $effectiveSenderOptions = Add-DefaultCliOption -Options $effectiveSenderOptions -Name '--connect-stagger-ms' -Value $env:MATRIX_SENDER_CONNECT_STAGGER_MS
         $effectiveSenderOptions = Add-DefaultCliOption -Options $effectiveSenderOptions -Name '--warmup' -Value $env:MATRIX_SENDER_WARMUP
+        $effectiveSenderOptions = Add-DefaultCliOption -Options $effectiveSenderOptions -Name '--payload' -Value $env:REQUEST_RESPONSE_SIZE
 
         $params = @{
           PeerName = 'netperf-peer'


### PR DESCRIPTION
## Summary

Adds rs_iof VMs to the `quicEcho` test matrix in `network-traffic-performance.yml` for kernel mode msquic performance testing, and scales the rs_iof run up to a high-concurrency profile so we can observe RSS / connection-scaling bottlenecks instead of single-connection RTT limits.

## Changes

### Workflow (`network-traffic-performance.yml`)
- Added `os: rsiof` coverage to `test_quic_echo` (env: lab, arch: x64)
- Added rs_iof sender defaults for scale testing:
  - `--connections 16`
  - `--outstanding 16`
  - `--connect-stagger-ms 0`
  - `--warmup 15`
- Derived the QUIC echo matrix from `receiver_options` so `--backend msquic-km` only schedules the supported rs_iof row and skips the unsupported `2022/ebpf` row
- Preserved caller overrides: explicit workflow `sender_options` still win over the rs_iof defaults

### Script (`run-quic-echo-test.ps1`)
- **`Ensure-MsQuicLoaded`** — verifies msquic.sys driver is loaded before starting WinQuicEcho (PE import dependency)
- **`Install-LocalWinQuicEchoKmDriver`** / **`Install-RemoteWinQuicEchoKmDriver`**:
  - Uses **relative ImagePath** (`system32\\drivers\\...`) instead of absolute `\\??\\C:\\...` — required on VMs with Code Integrity policy enforcement
  - Handles file-locked .sys files by renaming stale copies (kernel memory mapper holds locks even after unload)
  - Falls back through alternate service names when zombie service entries block creation
  - Robust stop verification with retry loop for remote installs
- **`Run-RecvTest`** — replaces `--server netperf-peer` with the local machine's hostname so the remote client connects back to the correct machine
- Added effective client concurrency logging so the run output shows the actual target scale (connections, outstanding requests, max in-flight requests, warmup, stagger)

## Test Results

### Initial validation on rs_iof VMs (rr1-netperf-47/48)
- **Send phase**: ~5,800 RPS, 173K requests, 0 errors ✅
- **Recv phase**: ~4,500 RPS, 136K requests, 0 errors ✅
- Successful runs: [26670140170](https://github.com/microsoft/netperf/actions/runs/26670140170), [26670427995](https://github.com/microsoft/netperf/actions/runs/26670427995)

### Scaled rs_iof validation (16 connections, 16 outstanding, 256 max in-flight)
- **Send phase**: **855,598.77 RPS**, **51,483,945** requests completed, **0 errors** ✅
- **Recv phase**: **363,769.68 RPS**, **22,018,615** requests completed, **0 errors** ✅
- Observed scale-up indicators:
  - Client started with **16/16 connected workers**
  - Kernel-mode server reported **ActiveConnections=16**
- Supporting run: [27426768019](https://github.com/microsoft/netperf/actions/runs/27426768019) (successful rs_iof job: [81067785232](https://github.com/microsoft/netperf/actions/runs/27426768019/job/81067785232))

## Technical Notes

- The `\\??\\` absolute path format that `sc.exe create` generates fails with ERROR_FILE_NOT_FOUND on these VMs despite the file being accessible. Using relative paths (like the msquic service itself) works reliably.
- Kernel driver .sys files remain memory-mapped after `sc.exe stop` + `sc.exe delete`. The workaround is to rename the stale file before copying the new one.
- `sc.exe delete` marks services for deletion but won't purge while the image is memory-mapped, creating zombie entries. The fallback to alternate service names handles this.
- The original ~6K RPS result was a single-connection / single-outstanding request workload. The new rs_iof defaults intentionally drive a multi-connection, multi-outstanding workload to expose scaling behavior.